### PR TITLE
Updating Annovar and GATK Docker containers to run the WDL 101 workflow

### DIFF
--- a/Dockerfile_annovar
+++ b/Dockerfile_annovar
@@ -3,8 +3,14 @@
 FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="annovar"
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
-LABEL org.opencontainers.image.description="Container image for the use of Annovar using GRCh38 in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Container image for the use of Annovar using hg19 in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="hg19"
+LABEL org.opencontainers.image.authors="tfirman@fredhutch.org"
+LABEL org.opencontainers.image.url=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.documentation=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
@@ -18,13 +24,12 @@ RUN tar -xvf annovar.latest.tar.gz
 ENV PATH="${PATH}:/annovar"
 
 # Downloading GRCh38 resources
-RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar refGene /annovar/humandb/
-RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar knownGene /annovar/humandb/
-RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar cosmic70 /annovar/humandb/
-RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar esp6500siv2_all /annovar/humandb/
-RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar clinvar_20180603 /annovar/humandb/
-RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar gnomad211_exome /annovar/humandb/
+RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar refGene /annovar/humandb/
+RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar knownGene /annovar/humandb/
+RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar cosmic70 /annovar/humandb/
+RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar esp6500siv2_all /annovar/humandb/
+RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar clinvar_20180603 /annovar/humandb/
+RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar gnomad211_exome /annovar/humandb/
 
 # Cleanup
-RUN rm /annovar/humandb/hg19_*
 RUN rm -rf annovar.latest.tar.gz

--- a/Dockerfile_gatk
+++ b/Dockerfile_gatk
@@ -14,3 +14,20 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing GATK via conda
 RUN conda install -c bioconda gatk4=4.3.0.0
+
+# Installing Samtools prerequisites
+RUN apt-get update \
+  && apt-get install -y build-essential wget zlib1g-dev autoconf automake libncurses5-dev libbz2-dev liblzma-dev libssl-dev libcurl4-gnutls-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pulling and extracting Samtools source code
+RUN wget https://github.com/samtools/samtools/releases/download/1.11/samtools-1.11.tar.bz2
+RUN tar -jxf samtools-1.11.tar.bz2
+
+# Installing Samtools
+WORKDIR /samtools-1.11
+RUN ./configure && make && make install
+WORKDIR /
+
+# Cleanup
+RUN rm -rf samtools-1.11 samtools-1.11.tar.bz2


### PR DESCRIPTION
**Updates**

- Adding extra labels to the Annovar Dockerfile
- Switching the default reference genome to hg19 in Annovar
- Adding samtools to the GATK Docker container for use during MarkDuplicates and BaseRecalibrator

