### PR TITLE
Switching Ubuntu base image versions for the Picard Dockerfiles

### DIFF
--- a/picard/Dockerfile_3.1.1
+++ b/picard/Dockerfile_3.1.1
@@ -1,6 +1,6 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20240114
+FROM ubuntu:jammy-20240212
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="picard"
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.url=https://hutchdatascience.org/
 LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
+
+# Setting environment variables
+ENV DEBIAN_FRONTEND noninteractive
 
 # Installing Java
 RUN apt-get update && \

--- a/picard/Dockerfile_latest
+++ b/picard/Dockerfile_latest
@@ -1,6 +1,6 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20240114
+FROM ubuntu:jammy-20240212
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="picard"
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.url=https://hutchdatascience.org/
 LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
+
+# Setting environment variables
+ENV DEBIAN_FRONTEND noninteractive
 
 # Installing Java
 RUN apt-get update && \


### PR DESCRIPTION
**Updates**

- The five second lag between Docker builds seems to be working in the GitHub Action, but the Picard build kept hanging.
- Turns out that the "r-base" package didn't like the Ubuntu version I was using and the Debian frontend needed to be set to noninteractive. Builds fine locally, just need to test it out on GitHub Actions.

