### PR TITLE
Fixing STAR and Excluding Cell Ranger from Build-and-Push Action

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           for TOOL in *
           do
-              if [ -d $TOOL ]; then
+              if [ -d $TOOL ] && [ "$TOOL" != "cellranger" ]; then
                   for TAG in $TOOL/*
                   do 
                       if [[ $TAG =~ Dockerfile_* ]]; then

--- a/cellranger/Dockerfile_6.0.2
+++ b/cellranger/Dockerfile_6.0.2
@@ -20,11 +20,14 @@ RUN apt-get update \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \
   && rm -rf /var/lib/apt/lists/*
 
-# Pulling and extracting bwa source code
+# Pulling and extracting Cell Ranger source code
 RUN wget -q --no-check-certificate -O cellranger-6.0.2.tar.gz \
   "https://cf.10xgenomics.com/releases/cell-exp/cellranger-6.0.2.tar.gz?Expires=1712197233&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=Sxa8s8vTFJqJ0rsWV7GlM7tzeN3za6JjXwF6FDhyZjhL5im-rj9fkxE~3r2TeUMcJm5ZnsyVI~5HelwT49fMrPA3FSZhVj1XRZ-gKAQwEq4vgn4~89cR1pod-xpHFDqUxAgEQDNb~JO835U6Y7Y~HCzJoxQZek2vqVToq-gLpO8~Ec6ktZn2IHqxA1~PE6Jkdjk9X6J1xZsXvZb1wnMu3bVCIS-3e-ifS8fxt4P~ciTwCs7TvKRDQykxCgCbbeFYw31aguJnCFL2GKBzt0SVyl6jU4ds8B067Pg2pO6yCz7bwRT6cByTyjzKvwloU4Fi4mDoEnk2ekGfIMjM4NkUsA__" && tar -zxvf cellranger-6.0.2.tar.gz
+# Note: Because the key for this link expires, these containers are 
+# excluded from the automated build-and-push GitHub Action. 
+# To make changes, provide an updated link and reupload manually.
 
-# Installing bwa
+# Installing Cell Ranger
 ENV PATH="${PATH}:/cellranger-6.0.2"
 
 # Cleanup

--- a/cellranger/Dockerfile_latest
+++ b/cellranger/Dockerfile_latest
@@ -20,11 +20,14 @@ RUN apt-get update \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \
   && rm -rf /var/lib/apt/lists/*
 
-# Pulling and extracting bwa source code
+# Pulling and extracting Cell Ranger source code
 RUN wget -q --no-check-certificate -O cellranger-6.0.2.tar.gz \
   "https://cf.10xgenomics.com/releases/cell-exp/cellranger-6.0.2.tar.gz?Expires=1712197233&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=Sxa8s8vTFJqJ0rsWV7GlM7tzeN3za6JjXwF6FDhyZjhL5im-rj9fkxE~3r2TeUMcJm5ZnsyVI~5HelwT49fMrPA3FSZhVj1XRZ-gKAQwEq4vgn4~89cR1pod-xpHFDqUxAgEQDNb~JO835U6Y7Y~HCzJoxQZek2vqVToq-gLpO8~Ec6ktZn2IHqxA1~PE6Jkdjk9X6J1xZsXvZb1wnMu3bVCIS-3e-ifS8fxt4P~ciTwCs7TvKRDQykxCgCbbeFYw31aguJnCFL2GKBzt0SVyl6jU4ds8B067Pg2pO6yCz7bwRT6cByTyjzKvwloU4Fi4mDoEnk2ekGfIMjM4NkUsA__" && tar -zxvf cellranger-6.0.2.tar.gz
+# Note: Because the key for this link expires, these containers are 
+# excluded from the automated build-and-push GitHub Action. 
+# To make changes, provide an updated link and reupload manually.
 
-# Installing bwa
+# Installing Cell Ranger
 ENV PATH="${PATH}:/cellranger-6.0.2"
 
 # Cleanup

--- a/star/Dockerfile_2.7.6a
+++ b/star/Dockerfile_2.7.6a
@@ -17,13 +17,13 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu2 \
+  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu3 \
   && rm -rf /var/lib/apt/lists/*
 
-# Pulling and extracting bwa source code
+# Pulling and extracting STAR source code
 RUN wget -q --no-check-certificate https://github.com/alexdobin/STAR/archive/2.7.6a.tar.gz && tar -xzf 2.7.6a.tar.gz
 
-# Installing bwa
+# Installing STAR
 WORKDIR /STAR-2.7.6a/source
 RUN make STAR
 WORKDIR /

--- a/star/Dockerfile_latest
+++ b/star/Dockerfile_latest
@@ -17,13 +17,13 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu2 \
+  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu3 \
   && rm -rf /var/lib/apt/lists/*
 
-# Pulling and extracting bwa source code
+# Pulling and extracting STAR source code
 RUN wget -q --no-check-certificate https://github.com/alexdobin/STAR/archive/2.7.6a.tar.gz && tar -xzf 2.7.6a.tar.gz
 
-# Installing bwa
+# Installing STAR
 WORKDIR /STAR-2.7.6a/source
 RUN make STAR
 WORKDIR /


### PR DESCRIPTION
## Description
- The xxd package in STAR keeps throwing an issue about the version not being available anymore.
    - Updating from "2:9.1.0016-1ubuntu2" to "2:9.1.0016-1ubuntu3"
- Because the Cell Ranger source code link eventually expires, we're excluding it from the build-and-push GitHub Action.
    - If you would like to make updates, get a new link and push to GHCR manually.
