### PR TITLE
Updating perl version in Annovar Dockerfiles

### DIFF
--- a/annovar/Dockerfile_hg19
+++ b/annovar/Dockerfile_hg19
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3.2build1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Annovar source code

--- a/annovar/Dockerfile_hg38
+++ b/annovar/Dockerfile_hg38
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3.2build1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Annovar source code

--- a/annovar/Dockerfile_latest
+++ b/annovar/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3.2build1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Annovar source code


### PR DESCRIPTION
## Description
- The perl package in Annovar keeps throwing an issue about the version not being available anymore.
    - Updating from "5.38.2-3.2" to "5.38.2-3.2build1"