### PR TITLE
Fixing apt-get versions for wget and perl in relevant Dockerfiles

### DIFF
--- a/annovar/Dockerfile_hg19
+++ b/annovar/Dockerfile_hg19
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3.2build1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 perl=5.38.2-3.2build2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Annovar source code

--- a/annovar/Dockerfile_hg38
+++ b/annovar/Dockerfile_hg38
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3.2build1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 perl=5.38.2-3.2build2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Annovar source code

--- a/annovar/Dockerfile_latest
+++ b/annovar/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 perl=5.38.2-3.2build1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 perl=5.38.2-3.2build2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Annovar source code

--- a/bwa/Dockerfile_0.7.17
+++ b/bwa/Dockerfile_0.7.17
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \

--- a/bwa/Dockerfile_latest
+++ b/bwa/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \

--- a/samtools/Dockerfile_1.11
+++ b/samtools/Dockerfile_1.11
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \

--- a/samtools/Dockerfile_latest
+++ b/samtools/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \

--- a/star/Dockerfile_2.7.6a
+++ b/star/Dockerfile_2.7.6a
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu3 \

--- a/star/Dockerfile_latest
+++ b/star/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
   libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu3 \


### PR DESCRIPTION
## Description
- The perl and wget packages in Annovar keep throwing an issue about the version not being available anymore.
    - Updating perl from "5.38.2-3.2build1" to "5.38.2-3.2build2"
    - Updating wget from "1.21.4-1ubuntu1" to "1.21.4-1ubuntu3"

