### PR TITLE
Updating lib versions in relevant Dockerfiles

### DIFF
--- a/bwa/Dockerfile_0.7.17
+++ b/bwa/Dockerfile_0.7.17
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Installing prerequisites
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
-  zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bwa source code

--- a/bwa/Dockerfile_latest
+++ b/bwa/Dockerfile_latest
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Installing prerequisites
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
-  zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bwa source code

--- a/samtools/Dockerfile_1.11
+++ b/samtools/Dockerfile_1.11
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Installing prerequisites
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
-  zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Samtools source code

--- a/samtools/Dockerfile_latest
+++ b/samtools/Dockerfile_latest
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Installing prerequisites
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
-  zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Samtools source code

--- a/star/Dockerfile_2.7.6a
+++ b/star/Dockerfile_2.7.6a
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Installing prerequisites
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
-  zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu3 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 xxd=2:9.1.0016-1ubuntu3 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting STAR source code

--- a/star/Dockerfile_latest
+++ b/star/Dockerfile_latest
@@ -15,9 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Installing prerequisites
 RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
-  zlib1g-dev=1:1.3.dfsg-3ubuntu1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.4.5-0.3 \
-  libssl-dev=3.0.10-1ubuntu4 libcurl4-gnutls-dev=8.5.0-2ubuntu2 xxd=2:9.1.0016-1ubuntu3 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 xxd=2:9.1.0016-1ubuntu3 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting STAR source code


### PR DESCRIPTION
## Description
- The zlib1g-dev, liblzma-dev, libssl-dev, and libcurl4-gnutls-dev packages in Ubuntu-based images keep throwing an issue about the version not being available anymore. Updating those versions to the current defaults.