### PR TITLE
Updating xxd version in STAR Dockerfiles

### DIFF
--- a/star/Dockerfile_2.7.6a
+++ b/star/Dockerfile_2.7.6a
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 xxd=2:9.1.0016-1ubuntu3 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 xxd=2:9.1.0016-1ubuntu7 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting STAR source code

--- a/star/Dockerfile_latest
+++ b/star/Dockerfile_latest
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 xxd=2:9.1.0016-1ubuntu3 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 xxd=2:9.1.0016-1ubuntu7 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting STAR source code


### PR DESCRIPTION
## Description
- The xxd package in STAR threw an issue about the version not being available anymore.
    - Updating xxd from "2:9.1.0016-1ubuntu3" to "2:9.1.0016-1ubuntu7"