### PR TITLE
Adding initial versions of bcftools, bedtools, and ConsensusVariants

### DIFF
--- a/bcftools/Dockerfile_1.19
+++ b/bcftools/Dockerfile_1.19
@@ -1,0 +1,29 @@
+
+# Using the Ubuntu base image
+FROM ubuntu:noble-20240114
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="bcftools"
+LABEL org.opencontainers.image.description="Container image for the use of bcftools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="1.19"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing prerequisites
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pulling and extracting bcftools source code
+RUN wget -q --no-check-certificate https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 && tar -xvf bcftools-1.19.tar.bz2
+WORKDIR /bcftools-1.19
+RUN make
+WORKDIR /
+ENV PATH="${PATH}:/bcftools-1.19"
+RUN rm -rf bcftools-1.19.tar.bz2

--- a/bcftools/Dockerfile_1.19
+++ b/bcftools/Dockerfile_1.19
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 git \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bcftools source code

--- a/bcftools/Dockerfile_latest
+++ b/bcftools/Dockerfile_latest
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 git \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bcftools source code

--- a/bcftools/Dockerfile_latest
+++ b/bcftools/Dockerfile_latest
@@ -1,0 +1,29 @@
+
+# Using the Ubuntu base image
+FROM ubuntu:noble-20240114
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="bcftools"
+LABEL org.opencontainers.image.description="Container image for the use of bcftools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing prerequisites
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pulling and extracting bcftools source code
+RUN wget -q --no-check-certificate https://github.com/samtools/bcftools/releases/download/1.19/bcftools-1.19.tar.bz2 && tar -xvf bcftools-1.19.tar.bz2
+WORKDIR /bcftools-1.19
+RUN make
+WORKDIR /
+ENV PATH="${PATH}:/bcftools-1.19"
+RUN rm -rf bcftools-1.19.tar.bz2

--- a/bedtools/Dockerfile_2.31.1
+++ b/bedtools/Dockerfile_2.31.1
@@ -1,0 +1,18 @@
+
+# Using the Ubuntu base image
+FROM ubuntu:noble-20240114
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="bedtools"
+LABEL org.opencontainers.image.description="Container image for the use of bedtools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="2.31.1"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing prerequisites
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 bedtools=2.31.1+dfsg-2 \
+  && rm -rf /var/lib/apt/lists/*

--- a/bedtools/Dockerfile_latest
+++ b/bedtools/Dockerfile_latest
@@ -1,0 +1,18 @@
+
+# Using the Ubuntu base image
+FROM ubuntu:noble-20240114
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="bedtools"
+LABEL org.opencontainers.image.description="Container image for the use of bedtools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing prerequisites
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 bedtools=2.31.1+dfsg-2 \
+  && rm -rf /var/lib/apt/lists/*

--- a/consensus/Dockerfile_0.1.1
+++ b/consensus/Dockerfile_0.1.1
@@ -1,0 +1,20 @@
+
+
+# Using the Ubuntu base image
+FROM rocker/tidyverse:3.6.0
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="consensus"
+LABEL org.opencontainers.image.description="Container image for the use of the ConsensusVariants R script in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="0.1.1"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Pulling and extracting Consensus Variants source code
+ENV GIT_SSL_NO_VERIFY=1
+RUN git clone --branch v0.1.1 https://github.com/FredHutch/tg-wdl-consensusVariants.git \
+  && mv tg-wdl-consensusVariants/unpaired/consensus-trio.R consensus-trio-unpaired.R \
+  && rm -rf tg-wdl-consensusVariants

--- a/consensus/Dockerfile_latest
+++ b/consensus/Dockerfile_latest
@@ -1,0 +1,20 @@
+
+
+# Using the Ubuntu base image
+FROM rocker/tidyverse:3.6.0
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="consensus"
+LABEL org.opencontainers.image.description="Container image for the use of the ConsensusVariants R script in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Pulling and extracting Consensus Variants source code
+ENV GIT_SSL_NO_VERIFY=1
+RUN git clone --branch v0.1.1 https://github.com/FredHutch/tg-wdl-consensusVariants.git \
+  && mv tg-wdl-consensusVariants/unpaired/consensus-trio.R consensus-trio-unpaired.R \
+  && rm -rf tg-wdl-consensusVariants


### PR DESCRIPTION
## Description
- To incorporate the [ww-vc-trio](https://github.com/getwilds/ww-vc-trio) WDL pipeline according to [WILDS WDL guidelines](https://getwilds.org/guide/wdlconfig.html), we need to add Docker containers for the following tools:
    - [bcftools](https://samtools.github.io/bcftools/bcftools.html) (bcftools): utilities for variant calling and manipulating VCFs and BCFs
    - [bedtools](https://bedtools.readthedocs.io/en/latest/) (bedtools): swiss-army knife of tools for a wide-range of genomics analysis tasks
    - [ConsensusVariants](https://github.com/FredHutch/tg-wdl-consensusVariants/blob/master/unpaired/consensus-trio.R) (consensus): set of R scripts that identify variants called consistently across three popular tools
