### PR TITLE
Switching from hard-links to copies in conda-based images

### DIFF
--- a/gatk/Dockerfile_4.3.0.0
+++ b/gatk/Dockerfile_4.3.0.0
@@ -12,6 +12,9 @@ LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Switching from hard-links to copies
+RUN conda config --set always_copy true
+
 # Installing GATK via conda
 RUN conda install -y -c bioconda gatk4=4.3.0.0
 

--- a/gatk/Dockerfile_latest
+++ b/gatk/Dockerfile_latest
@@ -12,6 +12,9 @@ LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Switching from hard-links to copies
+RUN conda config --set always_copy true
+
 # Installing GATK via conda
 RUN conda install -y -c bioconda gatk4=4.3.0.0
 

--- a/pfastqdump/Dockerfile_0.6.7
+++ b/pfastqdump/Dockerfile_0.6.7
@@ -12,5 +12,8 @@ LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Switching from hard-links to copies
+RUN conda config --set always_copy true
+
 # Installing GATK via conda
 RUN conda install -y -c bioconda parallel-fastq-dump=0.6.7 'sra-tools>=2.10.0'

--- a/pfastqdump/Dockerfile_latest
+++ b/pfastqdump/Dockerfile_latest
@@ -12,5 +12,8 @@ LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Switching from hard-links to copies
+RUN conda config --set always_copy true
+
 # Installing GATK via conda
 RUN conda install -y -c bioconda parallel-fastq-dump=0.6.7 'sra-tools>=2.10.0'


### PR DESCRIPTION
## Description

- Started getting some strange error messages when submitting WDL pipelines via PROOF, specifically when calling the `ghcr.io/getwilds/gatk:4.3.0.0` Docker image (see screenshot below).
- Reached out to [Dan Tenenbaum and Michael Gutteridge](https://fhdata.slack.com/archives/C068PB2EG01/p1712856874857829) and they figured out that it was because conda was trying to make a hard-link on scratch, which is a no-no on Rhino (a "Rhi-no-no" if you will).
- The bandaid fix for now is to explicitly make conda copy rather than hard-link, but a larger discussion will probably be on the horizon...
