### PR TITLE
Adding bedtools to samtools images

### DIFF
--- a/samtools/Dockerfile_1.11
+++ b/samtools/Dockerfile_1.11
@@ -14,10 +14,10 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
+  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu10.1 bedtools=2.31.1+dfsg-2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Samtools source code

--- a/samtools/Dockerfile_latest
+++ b/samtools/Dockerfile_latest
@@ -14,10 +14,10 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu3 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu1 libbz2-dev=1.0.8-5ubuntu1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu9 \
+  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1 liblzma-dev=5.6.1+really5.4.5-1 \
+  libssl-dev=3.0.13-0ubuntu3 libcurl4-gnutls-dev=8.5.0-2ubuntu10.1 bedtools=2.31.1+dfsg-2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting Samtools source code


### PR DESCRIPTION
## Description
Sanaz Agarwal mentioned a scenario where his code requires samtools and bedtools to be referred to in the same task, and therefore be available in the same image, so the following updates were added:
- Bedtools was added to the `apt-get install` call on line 16
- Versions of other apt-get were updated to most recent versions
