### PR TITLE
Pushing Docker images to DockerHub as well

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -43,6 +43,21 @@ jobs:
                   sleep 5
               fi
           done
-
-
+      -
+        name: Login to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PW }}
+      -
+        name: Build and Push
+        run: |
+          for changed_file in ${{ steps.files.outputs.added_modified }}; do
+              if [[ $changed_file == *"Dockerfile_"* ]]; then
+                  IFS="/" read -ra toolarr <<< "$changed_file"
+                  IFS="_" read -ra tagarr <<< "$changed_file"
+                  docker build --platform linux/amd64 -t getwilds/${toolarr[0]}:${tagarr[-1]} -f ${changed_file} --push .
+                  sleep 5
+              fi
+          done
 

--- a/annovar/Dockerfile_hg19
+++ b/annovar/Dockerfile_hg19
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="annovar"
-LABEL org.opencontainers.image.description="Container image for the use of Annovar using hg19 in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of Annovar using hg19 in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="hg19"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/annovar/Dockerfile_hg38
+++ b/annovar/Dockerfile_hg38
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="annovar"
-LABEL org.opencontainers.image.description="Container image for the use of Annovar using hg38 in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of Annovar using hg38 in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="hg38"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/annovar/Dockerfile_latest
+++ b/annovar/Dockerfile_latest
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="annovar"
-LABEL org.opencontainers.image.description="Container image for the use of Annovar using hg19 in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of Annovar using hg19 in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/bedtools/Dockerfile_2.31.1
+++ b/bedtools/Dockerfile_2.31.1
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bedtools"
-LABEL org.opencontainers.image.description="Container image for the use of bedtools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of bedtools in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="2.31.1"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/bedtools/Dockerfile_latest
+++ b/bedtools/Dockerfile_latest
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bedtools"
-LABEL org.opencontainers.image.description="Container image for the use of bedtools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of bedtools in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/bwa/Dockerfile_0.7.17
+++ b/bwa/Dockerfile_0.7.17
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bwa"
-LABEL org.opencontainers.image.description="Container image for the use of bwa in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of bwa in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="0.7.17"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/bwa/Dockerfile_latest
+++ b/bwa/Dockerfile_latest
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20240114
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bwa"
-LABEL org.opencontainers.image.description="Container image for the use of bwa in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of bwa in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/umitools/Dockerfile_1.0.1
+++ b/umitools/Dockerfile_1.0.1
@@ -4,7 +4,7 @@ FROM python:3.9.19-bookworm
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="umitools"
-LABEL org.opencontainers.image.description="Container image for the use of umi_tools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of umi_tools in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="1.0.1"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/

--- a/umitools/Dockerfile_latest
+++ b/umitools/Dockerfile_latest
@@ -4,7 +4,7 @@ FROM python:3.9.19-bookworm
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="umitools"
-LABEL org.opencontainers.image.description="Container image for the use of umi_tools in FH DaSL's WILDS"
+LABEL org.opencontainers.image.description="Docker image for the use of umi_tools in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/


### PR DESCRIPTION
## Description
Because of a recent realization that Cromwell does not allow call caching with ghcr.io-based images, we now need to push a copy of each Docker image to DockerHub as well.