### PR TITLE
Adding Docker Scout Security Action

### DIFF
--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -44,9 +44,9 @@ jobs:
             if [[ $(wc -c cves.html) -le 65536 ]]; then
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cves.html
             else
-              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally." > quickview.txt
-              docker scout quickview getwilds/bwa:latest >> quickview.txt
-              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file quickview.html
+              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally." > qv.txt
+              docker scout quickview getwilds/bwa:latest >> qv.txt
+              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
             fi
           fi
         # id: docker-scout

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -44,9 +44,9 @@ jobs:
             if [[ $(wc -c cve_check.html) -le 65536 ]]; then
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
             else
-              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally.\n```" > qv.txt
+              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally.\n\`\`\`" > qv.txt
               docker scout quickview getwilds/bwa:latest >> qv.txt
-              echo "```" > qv.txt
+              echo "\`\`\`" >> qv.txt
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
             fi
           fi

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -13,18 +13,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
-      - name: Build
-        run: docker build --platform linux/amd64 -t bwa-scout -f bwa/Dockerfile_latest .
+      # - name: Build
+      #   run: docker build --platform linux/amd64 -t bwa-scout -f bwa/Dockerfile_latest .
+        # docker scout cves bwa-test --only-fixed --format markdown | gh issue create --repo getwilds/wilds-docker-library --title "bwa CVE Analysis" --body-file -
+        # docker scout cves getwilds/gatk:latest --only-fixed --format sarif --output test.json \
+        #   && jq '.runs[0].tool.driver.rules | length' test.json
       - name: Docker Scout
-        id: docker-scout
-        uses: docker/scout-action@v1
-        with:
-          command: cves,recommendations
-          only-fixed: true
+        run: |
+          if [[ $(docker scout cves getwilds/gatk:latest --only-fixed --format sarif --output test.json \
+          && jq '.runs[0].tool.driver.rules | length' test.json) -ge 1 ]]; then
+            docker scout cves getwilds/gatk:latest --only-fixed --format markdown \
+            | gh issue create --repo getwilds/wilds-docker-library --title "GATK CVE Analysis" --body-file -
+          fi
+        # id: docker-scout
+        # uses: docker/scout-action@v1
+        # with:
+        #   command: cves,recommendations
+        #   only-fixed: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -19,7 +19,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
       - name: Build
-        run: docker build --platform linux/amd64 -t getwilds/bwa:latest -f bwa/Dockerfile_latest .
+        run: |
+          ls
+          docker build --platform linux/amd64 -t getwilds/bwa:latest -f /bwa/Dockerfile_latest .
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  pull-requests: write
+
 jobs:
   scout:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -1,4 +1,4 @@
-name: Docker Scout Security Check
+name: Docker Scout
 
 on:
   pull_request:

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -11,11 +11,11 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
-      # - name: Login to DockerHub Container Registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USER }}
-      #     password: ${{ secrets.DOCKERHUB_PW }}
+      - name: Login to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PW }}
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -37,12 +37,12 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
-          docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output cves.json
-          NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cves.json)
+          docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output cve_check.json
+          NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)
           if [[ $NUM_VUL -ge 1 ]]; then
-            docker scout cves getwilds/bwa:latest --only-fixed --format markdown --output cves.html
-            if [[ $(wc -c cves.html) -le 65536 ]]; then
-              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cves.html
+            docker scout cves getwilds/bwa:latest --only-fixed --format markdown --output cve_check.html
+            if [[ $(wc -c cve_check.html) -le 65536 ]]; then
+              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
             else
               echo "Significant issues present in bwa, see quickview below and run CVE analysis locally." > qv.txt
               docker scout quickview getwilds/bwa:latest >> qv.txt

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -37,16 +37,18 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
-          docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output cve_check.json
+          CONTAINER="getwilds/bwa:latest"
+          docker scout cves $CONTAINER --only-fixed --format sarif --output cve_check.json
           NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)
           if [[ $NUM_VUL -ge 1 ]]; then
-            docker scout cves getwilds/bwa:latest --only-fixed --format markdown --output cve_check.html
+            docker scout cves $CONTAINER --only-fixed --format markdown --output cve_check.html
             if [[ $(wc -c cve_check.html) -le 65536 ]]; then
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
             else
-              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally.\n" > qv.txt
+              echo "Significant issues present in bwa, see quickview and recommendations below, but run CVE analysis locally.\n" > qv.txt
               echo "\`\`\`" >> qv.txt
-              docker scout quickview getwilds/bwa:latest >> qv.txt
+              docker scout quickview $CONTAINER >> qv.txt
+              docker scout recommendations $CONTAINER >> qv.txt
               echo "\`\`\`" >> qv.txt
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
             fi

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -45,14 +45,14 @@ jobs:
               if [[ $NUM_VUL -ge 1 ]]; then
                 docker scout cves $CONTAINER --only-fixed --format markdown --output cve_check.html
                 if [[ $(wc -c cve_check.html) -le 65536 ]]; then
-                  gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
+                  gh issue create --repo getwilds/wilds-docker-library --title "$image Vulnerability Analysis" --body-file cve_check.html
                 else
                   echo "Significant issues present in bwa, see quickview and recommendations below, but run CVE analysis locally." > qv.txt
                   echo "\`\`\`" >> qv.txt
                   docker scout quickview $CONTAINER >> qv.txt
                   docker scout recommendations $CONTAINER >> qv.txt
                   echo "\`\`\`" >> qv.txt
-                  gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
+                  gh issue create --repo getwilds/wilds-docker-library --title "$image Vulnerability Analysis" --body-file qv.txt
                 fi
               fi
             fi

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -55,6 +55,7 @@ jobs:
                   gh issue create --repo getwilds/wilds-docker-library --title "$image Vulnerability Analysis" --body-file qv.txt
                 fi
               fi
+              docker system prune -af
             fi
           done
         # id: docker-scout

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -22,12 +22,7 @@ jobs:
         with:
           command: cves,recommendations
           image: getwilds/bwa:latest
-          sarif-file: sarif.output.json
           platform: linux/amd64
           summary: true
-      - name: Upload SARIF result
-        id: upload-sarif
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: sarif.output.json
+          write-comment: true
+          keep-previous-comments: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -9,12 +9,12 @@ permissions:
 
 jobs:
   scout:
-    runs-on: ubuntu-latest
+    runs-on: docker/scout-cli
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -44,7 +44,8 @@ jobs:
             if [[ $(wc -c cve_check.html) -le 65536 ]]; then
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
             else
-              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally.\n\`\`\`" > qv.txt
+              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally.\n" > qv.txt
+              echo "\`\`\`" >> qv.txt
               docker scout quickview getwilds/bwa:latest >> qv.txt
               echo "\`\`\`" >> qv.txt
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -11,19 +11,20 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
+      - name: Build
+        run: docker build --platform linux/amd64 -t bwa-scout -f bwa/Dockerfile_latest .
       - name: Docker Scout
         id: docker-scout
-        if: ${{ github.event_name == 'pull_request' }}
         uses: docker/scout-action@v1
         with:
           command: cves,recommendations
-          image: getwilds/bwa:latest
-          platform: linux/amd64
-          summary: true
-          write-comment: true
-          keep-previous-comments: true
+          only-fixed: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -11,6 +11,8 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
@@ -19,9 +21,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
       - name: Build
-        run: |
-          echo $(ls)
-          docker build --platform linux/amd64 -t getwilds/bwa:latest -f /bwa/Dockerfile_latest .
+        run: docker build --platform linux/amd64 -t getwilds/bwa:latest -f bwa/Dockerfile_latest .
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -11,23 +11,29 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Checkout
+      #   uses: actions/checkout@v4
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
-      - name: Build
-        run: docker build --platform linux/amd64 -t getwilds/bwa:latest -f bwa/Dockerfile_latest .
+      # - name: Build
+      #   run: docker build --platform linux/amd64 -t getwilds/bwa:latest -f bwa/Dockerfile_latest .
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1
         with:
-          command: cves,recommendations,compare
-          to-latest: true
-          ignore-base: true
-          ignore-unchanged: true
-          only-fixed: true
+          command: cves,recommendations
+          image: getwilds/bwa:latest
+          sarif-file: sarif.output.json
+          platform: linux/amd64
+          summary: true
+      - name: Upload SARIF result
+        id: upload-sarif
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: sarif.output.json

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -7,12 +7,13 @@ on:
 env:
   GH_TOKEN: ${{ github.token }}
 
-permissions:
-  pull-requests: write
+# permissions:
+#   pull-requests: write
 
 jobs:
   scout:
     runs-on: ubuntu-latest
+    permissions: write-all
     # container:
     #   image: docker/scout-cli
     steps:

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PW }}
       - name: Build
         run: |
-          ls
+          echo $(ls)
           docker build --platform linux/amd64 -t getwilds/bwa:latest -f /bwa/Dockerfile_latest .
       - name: Docker Scout
         id: docker-scout

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -11,19 +11,20 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to DockerHub Container Registry
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
-      # - Build image here? How do you cycle through modified images?
+      - name: Build
+        run: docker build --platform linux/amd64 -t getwilds/bwa:latest -f bwa/Dockerfile_latest .
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1
         with:
-          image: getwilds/bwa:latest
-          command: cves #,recommendations,compare
+          command: cves,recommendations,compare
           to-latest: true
           ignore-base: true
           ignore-unchanged: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -37,10 +37,17 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
-          if [[ $(docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output test.json \
-          && jq '.runs[0].tool.driver.rules | length' test.json) -ge 1 ]]; then
-            docker scout cves getwilds/bwa:latest --only-fixed --format markdown \
-            | gh issue create --repo getwilds/wilds-docker-library --title "GATK CVE Analysis" --body-file -
+          docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output cves.json
+          NUM_VUL = $(jq '.runs[0].tool.driver.rules | length' cves.json)
+          if [[ $NUM_VUL -ge 1 ]]; then
+            docker scout cves getwilds/bwa:latest --only-fixed --format markdown --output cves.html
+            if [[ $(wc -c cves.html) -le 65536 ]]; then
+              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cves.html
+            else
+              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally." > quickview.txt
+              docker scout quickview getwilds/bwa:latest >> quickview.txt
+              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file quickview.html
+            fi
           fi
         # id: docker-scout
         # uses: docker/scout-action@v1

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -1,0 +1,19 @@
+name: Docker Scout Security Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  scout:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker Scout
+        id: docker-scout
+        uses: docker/scout-action@v1
+        with:
+          command: cves,recommendations,compare
+          to-latest: true
+          ignore-base: true
+          ignore-unchanged: true
+          only-fixed: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -9,12 +9,14 @@ permissions:
 
 jobs:
   scout:
-    runs-on: docker/scout-cli
+    runs-on: ubuntu-latest
+    container:
+      image: docker/scout-cli
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -1,36 +1,24 @@
 name: Docker Scout
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  schedule:
+    - cron: "0 0 20 * *"
 
 env:
   GH_TOKEN: ${{ github.token }}
-
-# permissions:
-#   pull-requests: write
 
 jobs:
   scout:
     runs-on: ubuntu-latest
     permissions: write-all
-    # container:
-    #   image: docker/scout-cli
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
-      # - name: Build
-      #   run: docker build --platform linux/amd64 -t bwa-scout -f bwa/Dockerfile_latest .
-        # docker scout cves bwa-test --only-fixed --format markdown | gh issue create --repo getwilds/wilds-docker-library --title "bwa CVE Analysis" --body-file -
-        # docker scout cves getwilds/gatk:latest --only-fixed --format sarif --output test.json \
-        #   && jq '.runs[0].tool.driver.rules | length' test.json
       - name: Install Docker Scout
         run: |
           curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
@@ -58,8 +46,3 @@ jobs:
               docker system prune -af
             fi
           done
-        # id: docker-scout
-        # uses: docker/scout-action@v1
-        # with:
-        #   command: cves,recommendations
-        #   only-fixed: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -37,9 +37,9 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
-          if [[ $(docker scout cves getwilds/gatk:latest --only-fixed --format sarif --output test.json \
+          if [[ $(docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output test.json \
           && jq '.runs[0].tool.driver.rules | length' test.json) -ge 1 ]]; then
-            docker scout cves getwilds/gatk:latest --only-fixed --format markdown \
+            docker scout cves getwilds/bwa:latest --only-fixed --format markdown \
             | gh issue create --repo getwilds/wilds-docker-library --title "GATK CVE Analysis" --body-file -
           fi
         # id: docker-scout

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -44,8 +44,9 @@ jobs:
             if [[ $(wc -c cve_check.html) -le 65536 ]]; then
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
             else
-              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally." > qv.txt
+              echo "Significant issues present in bwa, see quickview below and run CVE analysis locally.\n```" > qv.txt
               docker scout quickview getwilds/bwa:latest >> qv.txt
+              echo "```" > qv.txt
               gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
             fi
           fi

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -10,13 +10,13 @@ permissions:
 jobs:
   scout:
     runs-on: ubuntu-latest
-    container:
-      image: docker/scout-cli
+    # container:
+    #   image: docker/scout-cli
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -27,6 +27,10 @@ jobs:
         # docker scout cves bwa-test --only-fixed --format markdown | gh issue create --repo getwilds/wilds-docker-library --title "bwa CVE Analysis" --body-file -
         # docker scout cves getwilds/gatk:latest --only-fixed --format sarif --output test.json \
         #   && jq '.runs[0].tool.driver.rules | length' test.json
+      - name: Install Docker Scout
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
+          sh install-scout.sh
       - name: Docker Scout
         run: |
           if [[ $(docker scout cves getwilds/gatk:latest --only-fixed --format sarif --output test.json \

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -8,6 +8,12 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
+      -
+        name: Login to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PW }}
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -18,6 +18,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PW }}
       - name: Docker Scout
         id: docker-scout
+        if: ${{ github.event_name == 'pull_request' }}
         uses: docker/scout-action@v1
         with:
           command: cves,recommendations

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Docker Scout
         run: |
           docker scout cves getwilds/bwa:latest --only-fixed --format sarif --output cves.json
-          NUM_VUL = $(jq '.runs[0].tool.driver.rules | length' cves.json)
+          NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cves.json)
           if [[ $NUM_VUL -ge 1 ]]; then
             docker scout cves getwilds/bwa:latest --only-fixed --format markdown --output cves.html
             if [[ $(wc -c cves.html) -le 65536 ]]; then

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -17,12 +17,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PW }}
+      # - Build image here? How do you cycle through modified images?
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1
         with:
           image: getwilds/bwa:latest
-          command: cves,recommendations,compare
+          command: cves #,recommendations,compare
           to-latest: true
           ignore-base: true
           ignore-unchanged: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -37,21 +37,23 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
-          for image in ./*; do
-            CONTAINER="getwilds/$image:latest"
-            docker scout cves $CONTAINER --only-fixed --format sarif --output cve_check.json
-            NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)
-            if [[ $NUM_VUL -ge 1 ]]; then
-              docker scout cves $CONTAINER --only-fixed --format markdown --output cve_check.html
-              if [[ $(wc -c cve_check.html) -le 65536 ]]; then
-                gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
-              else
-                echo "Significant issues present in bwa, see quickview and recommendations below, but run CVE analysis locally." > qv.txt
-                echo "\`\`\`" >> qv.txt
-                docker scout quickview $CONTAINER >> qv.txt
-                docker scout recommendations $CONTAINER >> qv.txt
-                echo "\`\`\`" >> qv.txt
-                gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
+          for image in *; do
+            if [ -d "$image" ] && [ "$image" != ".github" ]; then
+              CONTAINER="getwilds/$image:latest"
+              docker scout cves $CONTAINER --only-fixed --format sarif --output cve_check.json
+              NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)
+              if [[ $NUM_VUL -ge 1 ]]; then
+                docker scout cves $CONTAINER --only-fixed --format markdown --output cve_check.html
+                if [[ $(wc -c cve_check.html) -le 65536 ]]; then
+                  gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
+                else
+                  echo "Significant issues present in bwa, see quickview and recommendations below, but run CVE analysis locally." > qv.txt
+                  echo "\`\`\`" >> qv.txt
+                  docker scout quickview $CONTAINER >> qv.txt
+                  docker scout recommendations $CONTAINER >> qv.txt
+                  echo "\`\`\`" >> qv.txt
+                  gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
+                fi
               fi
             fi
           done

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -11,17 +11,11 @@ jobs:
   scout:
     runs-on: ubuntu-latest
     steps:
-      # - name: Checkout
-      #   uses: actions/checkout@v4
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PW }}
-      # - name: Build
-      #   run: docker build --platform linux/amd64 -t getwilds/bwa:latest -f bwa/Dockerfile_latest .
+      # - name: Login to DockerHub Container Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USER }}
+      #     password: ${{ secrets.DOCKERHUB_PW }}
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@v1

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -1,6 +1,7 @@
 name: Docker Scout
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 * * * *"
 

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -21,6 +21,7 @@ jobs:
         id: docker-scout
         uses: docker/scout-action@v1
         with:
+          image: getwilds/bwa:latest
           command: cves,recommendations,compare
           to-latest: true
           ignore-base: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -2,7 +2,7 @@ name: Docker Scout
 
 on:
   schedule:
-    - cron: "0 0 20 * *"
+    - cron: "0 * * * *"
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -25,8 +25,9 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
+          GH_ISSUES=$(gh issue list)
           for image in *; do
-            if [ -d "$image" ] && [ "$image" != ".github" ]; then
+            if [ -d "$image" ] && [ "$image" != ".github" ] && [ $GH_ISSUES != *"$image Vulnerability Analysis"* ]; then
               CONTAINER="getwilds/$image:latest"
               docker scout cves $CONTAINER --only-fixed --format sarif --output cve_check.json
               NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -37,22 +37,24 @@ jobs:
           sh install-scout.sh
       - name: Docker Scout
         run: |
-          CONTAINER="getwilds/bwa:latest"
-          docker scout cves $CONTAINER --only-fixed --format sarif --output cve_check.json
-          NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)
-          if [[ $NUM_VUL -ge 1 ]]; then
-            docker scout cves $CONTAINER --only-fixed --format markdown --output cve_check.html
-            if [[ $(wc -c cve_check.html) -le 65536 ]]; then
-              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
-            else
-              echo "Significant issues present in bwa, see quickview and recommendations below, but run CVE analysis locally.\n" > qv.txt
-              echo "\`\`\`" >> qv.txt
-              docker scout quickview $CONTAINER >> qv.txt
-              docker scout recommendations $CONTAINER >> qv.txt
-              echo "\`\`\`" >> qv.txt
-              gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
+          for image in ./*; do
+            CONTAINER="getwilds/$image:latest"
+            docker scout cves $CONTAINER --only-fixed --format sarif --output cve_check.json
+            NUM_VUL=$(jq '.runs[0].tool.driver.rules | length' cve_check.json)
+            if [[ $NUM_VUL -ge 1 ]]; then
+              docker scout cves $CONTAINER --only-fixed --format markdown --output cve_check.html
+              if [[ $(wc -c cve_check.html) -le 65536 ]]; then
+                gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file cve_check.html
+              else
+                echo "Significant issues present in bwa, see quickview and recommendations below, but run CVE analysis locally." > qv.txt
+                echo "\`\`\`" >> qv.txt
+                docker scout quickview $CONTAINER >> qv.txt
+                docker scout recommendations $CONTAINER >> qv.txt
+                echo "\`\`\`" >> qv.txt
+                gh issue create --repo getwilds/wilds-docker-library --title "bwa Vulnerability Analysis" --body-file qv.txt
+              fi
             fi
-          fi
+          done
         # id: docker-scout
         # uses: docker/scout-action@v1
         # with:

--- a/bwa/Dockerfile_0.7.17
+++ b/bwa/Dockerfile_0.7.17
@@ -14,10 +14,10 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4 \
-  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3.1 libcurl4-gnutls-dev=8.5.0-2ubuntu10.1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4.1 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2.1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1build0.1 liblzma-dev=5.6.1+really5.4.5-1build0.1 \
+  libssl-dev=3.0.13-0ubuntu3.4 libcurl4-gnutls-dev=8.5.0-2ubuntu10.4 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bwa source code

--- a/bwa/Dockerfile_0.7.17
+++ b/bwa/Dockerfile_0.7.17
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4.1 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2.1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1build0.1 liblzma-dev=5.6.1+really5.4.5-1build0.1 \
-  libssl-dev=3.0.13-0ubuntu3.4 libcurl4-gnutls-dev=8.5.0-2ubuntu10.4 \
+  libssl-dev=3.0.13-0ubuntu3.4 libcurl4-gnutls-dev=8.5.0-2ubuntu10.4 gnutls-bin=3.8.3-1.1ubuntu3.2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bwa source code

--- a/bwa/Dockerfile_0.7.17
+++ b/bwa/Dockerfile_0.7.17
@@ -1,6 +1,6 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20240114
+FROM ubuntu:noble-20241011
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bwa"

--- a/bwa/Dockerfile_latest
+++ b/bwa/Dockerfile_latest
@@ -14,10 +14,10 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4 \
-  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3.1 libcurl4-gnutls-dev=8.5.0-2ubuntu10.1 \
+  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4.1 \
+  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2.1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
+  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1build0.1 liblzma-dev=5.6.1+really5.4.5-1build0.1 \
+  libssl-dev=3.0.13-0ubuntu3.4 libcurl4-gnutls-dev=8.5.0-2ubuntu10.4 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bwa source code

--- a/bwa/Dockerfile_latest
+++ b/bwa/Dockerfile_latest
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4.1 \
   zlib1g-dev=1:1.3.dfsg-3.1ubuntu2.1 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1build0.1 liblzma-dev=5.6.1+really5.4.5-1build0.1 \
-  libssl-dev=3.0.13-0ubuntu3.4 libcurl4-gnutls-dev=8.5.0-2ubuntu10.4 \
+  libssl-dev=3.0.13-0ubuntu3.4 libcurl4-gnutls-dev=8.5.0-2ubuntu10.4 gnutls-bin=3.8.3-1.1ubuntu3.2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bwa source code

--- a/bwa/Dockerfile_latest
+++ b/bwa/Dockerfile_latest
@@ -1,6 +1,6 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20240114
+FROM ubuntu:noble-20241011
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bwa"


### PR DESCRIPTION
## Description
- Testing out the addition of an security-related GitHub Action.
- Every month, this action will run Docker Scout on the "latest" version of each Docker image.
- If fixable vulnerabilities are detected, it will post an issue to the repo describing the vulnerability.
- If there's already an existing vulnerability issue from last month, it will skip it (don't want infinite issues).
- Can also be triggered manually if needed.
- Currently running hourly for testing purposes.
- Eventually want to create a similar GitHub Action for PR's into main as a required check.
    - See bot comments on this PR below for an example output.
- Also fixing a security vulnerability in `bwa` while I'm at it.

## Related Issue
- Addresses #46

## Testing
- See the massive amounts of `security-action` GitHub Actions in the past few days.
