### PR TITLE
Updating base image of bedtools Docker images

### DIFF
--- a/bedtools/Dockerfile_2.31.1
+++ b/bedtools/Dockerfile_2.31.1
@@ -1,6 +1,6 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20240114
+FROM ubuntu:noble-20241011
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bedtools"

--- a/bedtools/Dockerfile_latest
+++ b/bedtools/Dockerfile_latest
@@ -1,6 +1,6 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20240114
+FROM ubuntu:noble-20241011
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bedtools"


### PR DESCRIPTION
## Description
- Updating the base image of the `bedtools` Docker images based on Docker Scout's suggestion.

## Related Issue
- Fixes #106 

## Testing & Examples
- Built local copy successfully.