### PR TITLE
Fixing build-and-push GH Action

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -40,6 +40,7 @@ jobs:
                   IFS="/" read -ra toolarr <<< "$changed_file"
                   IFS="_" read -ra tagarr <<< "$changed_file"
                   docker build --platform linux/amd64 -t ghcr.io/getwilds/${toolarr[0]}:${tagarr[-1]} -f ${changed_file} --push .
+                  docker system prune -af
                   sleep 5
               fi
           done
@@ -57,6 +58,7 @@ jobs:
                   IFS="/" read -ra toolarr <<< "$changed_file"
                   IFS="_" read -ra tagarr <<< "$changed_file"
                   docker build --platform linux/amd64 -t getwilds/${toolarr[0]}:${tagarr[-1]} -f ${changed_file} --push .
+                  docker system prune -af
                   sleep 5
               fi
           done

--- a/annovar/Dockerfile_hg19
+++ b/annovar/Dockerfile_hg19
@@ -32,3 +32,4 @@ RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar refGene /annov
 # Cleanup
 RUN rm -rf annovar.latest.tar.gz
 
+

--- a/annovar/Dockerfile_hg38
+++ b/annovar/Dockerfile_hg38
@@ -32,3 +32,4 @@ RUN annotate_variation.pl -buildver hg38 -downdb -webfrom annovar refGene /annov
 # Cleanup
 RUN rm -rf annovar.latest.tar.gz /annovar/humandb/hg19_*
 
+

--- a/annovar/Dockerfile_latest
+++ b/annovar/Dockerfile_latest
@@ -32,3 +32,4 @@ RUN annotate_variation.pl -buildver hg19 -downdb -webfrom annovar refGene /annov
 # Cleanup
 RUN rm -rf annovar.latest.tar.gz
 
+

--- a/bcftools/Dockerfile_1.11
+++ b/bcftools/Dockerfile_1.11
@@ -28,3 +28,4 @@ WORKDIR /
 ENV PATH="${PATH}:/bcftools-1.11"
 RUN rm -rf bcftools-1.11.tar.bz2
 
+

--- a/bcftools/Dockerfile_1.19
+++ b/bcftools/Dockerfile_1.19
@@ -28,3 +28,4 @@ WORKDIR /
 ENV PATH="${PATH}:/bcftools-1.19"
 RUN rm -rf bcftools-1.19.tar.bz2
 
+

--- a/bcftools/Dockerfile_latest
+++ b/bcftools/Dockerfile_latest
@@ -28,3 +28,4 @@ WORKDIR /
 ENV PATH="${PATH}:/bcftools-1.19"
 RUN rm -rf bcftools-1.19.tar.bz2
 
+

--- a/biobambam2/Dockerfile_2.0.185
+++ b/biobambam2/Dockerfile_2.0.185
@@ -17,3 +17,4 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends biobambam2=2.0.185+ds-1 \
   && rm -rf /var/lib/apt/lists/*
 
+

--- a/biobambam2/Dockerfile_latest
+++ b/biobambam2/Dockerfile_latest
@@ -17,3 +17,4 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends biobambam2=2.0.185+ds-1 \
   && rm -rf /var/lib/apt/lists/*
 
+

--- a/picard/Dockerfile_3.1.1
+++ b/picard/Dockerfile_3.1.1
@@ -27,3 +27,4 @@ RUN export JAVA_HOME
 # Pulling Picard jar to a location that will persist in Apptainer
 RUN mkdir /usr/picard && wget -q --no-check-certificate -P /usr/picard/ \
 https://github.com/broadinstitute/picard/releases/download/3.1.1/picard.jar
+

--- a/picard/Dockerfile_latest
+++ b/picard/Dockerfile_latest
@@ -27,3 +27,4 @@ RUN export JAVA_HOME
 # Pulling Picard jar to a location that will persist in Apptainer
 RUN mkdir /usr/picard && wget -q --no-check-certificate -P /usr/picard/ \
 https://github.com/broadinstitute/picard/releases/download/3.1.1/picard.jar
+

--- a/rnaseqc/Dockerfile_2.4.2
+++ b/rnaseqc/Dockerfile_2.4.2
@@ -31,3 +31,4 @@ WORKDIR /usr/rnaseqc
 RUN gunzip rnaseqc.v2.4.2.linux.gz && chmod a+x rnaseqc.v2.4.2.linux && mv rnaseqc.v2.4.2.linux rnaseqc
 WORKDIR /
 ENV PATH="${PATH}:/usr/rnaseqc"
+

--- a/rnaseqc/Dockerfile_latest
+++ b/rnaseqc/Dockerfile_latest
@@ -31,3 +31,4 @@ WORKDIR /usr/rnaseqc
 RUN gunzip rnaseqc.v2.4.2.linux.gz && chmod a+x rnaseqc.v2.4.2.linux && mv rnaseqc.v2.4.2.linux rnaseqc
 WORKDIR /
 ENV PATH="${PATH}:/usr/rnaseqc"
+

--- a/samtools/Dockerfile_1.10
+++ b/samtools/Dockerfile_1.10
@@ -30,3 +30,4 @@ WORKDIR /
 
 # Cleanup
 RUN rm -rf samtools-1.10 samtools-1.10.tar.bz2
+

--- a/samtools/Dockerfile_1.11
+++ b/samtools/Dockerfile_1.11
@@ -30,3 +30,4 @@ WORKDIR /
 
 # Cleanup
 RUN rm -rf samtools-1.11 samtools-1.11.tar.bz2
+

--- a/samtools/Dockerfile_latest
+++ b/samtools/Dockerfile_latest
@@ -30,3 +30,4 @@ WORKDIR /
 
 # Cleanup
 RUN rm -rf samtools-1.11 samtools-1.11.tar.bz2
+

--- a/scanpy/Dockerfile_1.10.2
+++ b/scanpy/Dockerfile_1.10.2
@@ -14,3 +14,4 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing packages via pip
 RUN pip install --no-cache-dir scanpy==1.10.2 leiden-clustering==0.1.0
+

--- a/scanpy/Dockerfile_latest
+++ b/scanpy/Dockerfile_latest
@@ -14,3 +14,4 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing packages via pip
 RUN pip install --no-cache-dir scanpy==1.10.2 leiden-clustering==0.1.0
+

--- a/scvi-tools/Dockerfile_1.1.6
+++ b/scvi-tools/Dockerfile_1.1.6
@@ -16,3 +16,4 @@ LABEL org.opencontainers.image.licenses=MIT
 # For GPU enabled abilities (from https://pytorch.org/get-started/locally/) - torch, torchvision, torchaudio
 RUN pip install --no-cache-dir scvi-tools==1.1.6 scanpy==1.10.2 leiden-clustering==0.1.0 scikit-misc==0.5.1 \
   && pip install --no-cache-dir torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 --index-url https://download.pytorch.org/whl/cu118
+

--- a/scvi-tools/Dockerfile_latest
+++ b/scvi-tools/Dockerfile_latest
@@ -16,3 +16,4 @@ LABEL org.opencontainers.image.licenses=MIT
 # For GPU enabled abilities (from https://pytorch.org/get-started/locally/) - torch, torchvision, torchaudio
 RUN pip install --no-cache-dir scvi-tools==1.1.6 scanpy==1.10.2 leiden-clustering==0.1.0 scikit-misc==0.5.1 \
   && pip install --no-cache-dir torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 --index-url https://download.pytorch.org/whl/cu118
+

--- a/umitools/Dockerfile_1.1.6
+++ b/umitools/Dockerfile_1.1.6
@@ -14,3 +14,4 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing umi_tools via pip
 RUN pip install --no-cache-dir umi_tools==1.1.6
+

--- a/umitools/Dockerfile_latest
+++ b/umitools/Dockerfile_latest
@@ -14,3 +14,4 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing umi_tools via pip
 RUN pip install --no-cache-dir umi_tools==1.1.6
+


### PR DESCRIPTION
## Description
- Previous build-and-push GitHub Action failed out due to lack of memory
- Added `docker system prune -af` after each build-and-push to alleviate that
- Also added dummy changes to each of the previous Dockerfiles to retrigger the action for them

## Testing
- No functional change for any of the Dockerfiles and very minor change for the GH Action