### PR TITLE
Fixing prerequisites in STAR 2.7.4a image

### DIFF
--- a/star/Dockerfile_2.7.4a
+++ b/star/Dockerfile_2.7.4a
@@ -17,7 +17,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.24.5-1ubuntu2 \
   zlib1g-dev=1:1.3.dfsg+really1.3.1-1ubuntu1 autoconf=2.72-3 automake=1:1.16.5-1.3ubuntu1 \
   libncurses-dev=6.5-2 libbz2-dev=1.0.8-6 liblzma-dev=5.6.2-2 libssl-dev=3.3.1-2ubuntu2 \
-  libcurl4-gnutls-dev=8.9.1-2ubuntu2 xxd=2:9.1.0496-1ubuntu6 \
+  libcurl4-gnutls-dev=8.9.1-2ubuntu2.1 xxd=2:9.1.0496-1ubuntu6 \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting STAR source code


### PR DESCRIPTION
## Description
- Fixing a version error in one of the prerequisites for STAR v2.7.4a.

## Testing
- Built locally, works great.