### PR TITLE
Adding initial versions of gtf-smash Docker image

### DIFF
--- a/gtf-smash/Dockerfile_latest
+++ b/gtf-smash/Dockerfile_latest
@@ -1,0 +1,26 @@
+
+# Using Python base image
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gtf-smash"
+LABEL org.opencontainers.image.description="Container image for the use of the gtf collapser necessary for RNASeQC"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing wget
+RUN apt-get update && \
+    apt-get install -y wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pulling down collapse_annotation.py script from GitHub
+RUN wget https://raw.githubusercontent.com/broadinstitute/gtex-pipeline/refs/tags/gtex_v8/gene_model/collapse_annotation.py
+
+# Installing packages via pip
+RUN pip install --no-cache-dir pandas==2.2.3 bx-python==0.13.0
+

--- a/gtf-smash/Dockerfile_latest
+++ b/gtf-smash/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing wget
 RUN apt-get update && \
-    apt-get install -y wget && \
+    apt-get install -y --no-install-recommends wget=1.21.3-1+b2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/gtf-smash/Dockerfile_v8
+++ b/gtf-smash/Dockerfile_v8
@@ -1,0 +1,26 @@
+
+# Using Python base image
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gtf-smash"
+LABEL org.opencontainers.image.description="Container image for the use of the gtf collapser necessary for RNASeQC"
+LABEL org.opencontainers.image.version="v8"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing wget
+RUN apt-get update && \
+    apt-get install -y wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pulling down collapse_annotation.py script from GitHub
+RUN wget https://raw.githubusercontent.com/broadinstitute/gtex-pipeline/refs/tags/gtex_v8/gene_model/collapse_annotation.py
+
+# Installing packages via pip
+RUN pip install --no-cache-dir pandas==2.2.3 bx-python==0.13.0
+

--- a/gtf-smash/Dockerfile_v8
+++ b/gtf-smash/Dockerfile_v8
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 
 # Installing wget
 RUN apt-get update && \
-    apt-get install -y wget && \
+    apt-get install -y --no-install-recommends wget=1.21.3-1+b2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description
- Adding initial version of gtf-smash Docker image for use in the ww-star-deseq2 WDL script.

## Testing
- Built locally, works great.