### PR TITLE
Sticking to latest version of collapse_annotation.py

### DIFF
--- a/gtf-smash/Dockerfile_latest
+++ b/gtf-smash/Dockerfile_latest
@@ -20,7 +20,7 @@ RUN apt-get update && \
 
 # Pulling down collapse_annotation.py script from GitHub
 WORKDIR /usr/gtf-smash
-RUN wget https://raw.githubusercontent.com/broadinstitute/gtex-pipeline/refs/tags/gtex_v8/gene_model/collapse_annotation.py && \
+RUN wget https://raw.githubusercontent.com/broadinstitute/gtex-pipeline/refs/heads/master/gene_model/collapse_annotation.py && \
     chmod +x collapse_annotation.py
 WORKDIR /
 ENV PATH="${PATH}:/usr/gtf-smash"


### PR DESCRIPTION
## Description
- Sticking to latest version of collapse_annotation.py and deleting v8