### PR TITLE
Addressing CVE's in bedtools image

### DIFF
--- a/bedtools/Dockerfile_2.31.1
+++ b/bedtools/Dockerfile_2.31.1
@@ -1,19 +1,25 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20241011
+FROM ubuntu:24.04
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bedtools"
 LABEL org.opencontainers.image.description="Docker image for the use of bedtools in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="2.31.1"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
-LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
 LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 bedtools=2.31.1+dfsg-2 \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  bedtools=2.31.1+dfsg-2 \
   && rm -rf /var/lib/apt/lists/*
 

--- a/bedtools/Dockerfile_latest
+++ b/bedtools/Dockerfile_latest
@@ -1,19 +1,25 @@
 
 # Using the Ubuntu base image
-FROM ubuntu:noble-20241011
+FROM ubuntu:24.04
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="bedtools"
 LABEL org.opencontainers.image.description="Docker image for the use of bedtools in FH DaSL's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
-LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
 LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 bedtools=2.31.1+dfsg-2 \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  bedtools=2.31.1+dfsg-2 \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description
- Updating underlying Linux packages in bedtools image to address CVE's identified by Docker Scout

## Related Issue
- Fixes #162 

## Testing
- Built locally, compiles as expected, no changes to the installation of bedtools itself.