### PR TITLE
Updating Build/Push/Update GHA Working Directory

### DIFF
--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -144,11 +144,17 @@ jobs:
               
               echo "Building image for $tool_name:$tag"
               
+              # Change directory to the tool directory for proper context
+              cd "${tool_name}"
+              
               # Build and push to GitHub Container Registry
-              docker build --platform linux/amd64 -t "ghcr.io/getwilds/${tool_name}:${tag}" -f "${changed_file}" --push .
+              docker build --platform linux/amd64 -t "ghcr.io/getwilds/${tool_name}:${tag}" -f "Dockerfile_${tag}" --push .
               
               # Build and push to DockerHub
-              docker build --platform linux/amd64 -t "getwilds/${tool_name}:${tag}" -f "${changed_file}" --push .
+              docker build --platform linux/amd64 -t "getwilds/${tool_name}:${tag}" -f "Dockerfile_${tag}" --push .
+              
+              # Go back to the root directory
+              cd ..
               
               # Clean up to save space
               docker system prune -af

--- a/biobambam2/Dockerfile_2.0.185
+++ b/biobambam2/Dockerfile_2.0.185
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version="2.0.185"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/
 LABEL org.opencontainers.image.documentation=https://getwilds.org/
-LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library/biobambam2
 LABEL org.opencontainers.image.licenses=MIT
 
 # Installing biobambam2 via apt-get

--- a/biobambam2/Dockerfile_latest
+++ b/biobambam2/Dockerfile_latest
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://hutchdatascience.org/
 LABEL org.opencontainers.image.documentation=https://getwilds.org/
-LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library/biobambam2
 LABEL org.opencontainers.image.licenses=MIT
 
 # Installing biobambam2 via apt-get


### PR DESCRIPTION
## Description
- Within the Build/Push/Update GitHub Action, we navigate to each tool's subdirectory and push the image from there to make sure the Docker context is correct.
- Also updating the biobambam2 Dockerfile to point to the subdirectory as the source location.

## Testing
- Tested via a manual trigger, didn't work, but trying in the main branch.