### PR TITLE
Adding python-based `combine-counts` image for `ww-star-deseq2`

### DIFF
--- a/combine-counts/Dockerfile_0.1.0
+++ b/combine-counts/Dockerfile_0.1.0
@@ -1,0 +1,21 @@
+
+# Using Python base image
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="combine-counts"
+LABEL org.opencontainers.image.description="Container image for the count matrix assembly necessary for DESeq2"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing packages via pip
+RUN pip install --no-cache-dir pandas==2.2.3
+
+# Copying combine_star_counts.py script from the repo
+COPY combine-counts/combine_star_counts.py /usr/local/bin/
+RUN chmod +x /usr/local/bin/combine_star_counts.py
+

--- a/combine-counts/Dockerfile_latest
+++ b/combine-counts/Dockerfile_latest
@@ -1,0 +1,21 @@
+
+# Using Python base image
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="combine-counts"
+LABEL org.opencontainers.image.description="Container image for the count matrix assembly necessary for DESeq2"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://hutchdatascience.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Installing packages via pip
+RUN pip install --no-cache-dir pandas==2.2.3
+
+# Copying combine_star_counts.py script from the repo
+COPY combine-counts/combine_star_counts.py /usr/local/bin/
+RUN chmod +x /usr/local/bin/combine_star_counts.py
+

--- a/combine-counts/README
+++ b/combine-counts/README
@@ -1,0 +1,96 @@
+# combine-counts
+
+This directory contains Docker images for combine-counts, a Python-based toolkit for combining STAR RNA-seq count matrices for downstream analysis in DESeq2.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/combine-counts/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/combine-counts/CVEs_latest.md) )
+- `0.1.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/combine-counts/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/combine-counts/CVEs_0.1.0.md) )
+
+## Image Details
+
+These Docker images are built from the Python 3.12-slim base image and include:
+
+- combine_star_counts.py: A Python script for combining individual STAR count matrices into a single matrix
+- pandas: Python data manipulation library for efficient data processing
+- Template generation for DESeq2 sample metadata
+
+The images are designed to provide a streamlined environment for preparing RNA-seq count data for differential expression analysis.
+
+## Usage
+
+### Docker
+
+```bash
+docker pull getwilds/combine-counts:latest
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/combine-counts:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+apptainer pull docker://getwilds/combine-counts:latest
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/combine-counts:latest
+```
+
+### Example Commands
+
+```bash
+# Docker - Process multiple count files
+docker run --rm -v /path/to/data:/data getwilds/combine-counts:latest python /usr/combine-counts/combine_star_counts.py \
+  --input /data/sample1.ReadsPerGene.out.tab /data/sample2.ReadsPerGene.out.tab /data/sample3.ReadsPerGene.out.tab \
+  --output /data/combined_counts.txt \
+  --metadata /data/sample_metadata.txt
+
+# With stranded RNA-seq data (column 3 = forward strand, column 4 = reverse strand)
+docker run --rm -v /path/to/data:/data getwilds/combine-counts:latest python /usr/combine-counts/combine_star_counts.py \
+  --input /data/sample1.ReadsPerGene.out.tab /data/sample2.ReadsPerGene.out.tab \
+  --output /data/combined_counts.txt \
+  --count_column 3
+
+# Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/combine-counts:latest python /usr/combine-counts/combine_star_counts.py \
+  --input /data/sample1.ReadsPerGene.out.tab /data/sample2.ReadsPerGene.out.tab \
+  --output /data/combined_counts.txt
+
+# Apptainer (local SIF file)
+apptainer run --bind /path/to/data:/data combine-counts_latest.sif python /usr/combine-counts/combine_star_counts.py \
+  --input /data/sample1.ReadsPerGene.out.tab /data/sample2.ReadsPerGene.out.tab \
+  --output /data/combined_counts.txt
+```
+
+## Security Features
+
+The combine-counts Docker images include:
+
+- Python 3.12 slim base for minimal attack surface
+- Pinned versions for all dependencies to ensure reproducibility
+- Minimal installation with only required dependencies
+- Permission settings to ensure script execution
+
+### Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/tree/main/combine-counts), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Python 3.12-slim as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs pandas with a pinned version
+4. Copies the combine_star_counts.py script to the container
+5. Makes the script executable and adds it to PATH
+6. Sets up appropriate working directories
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.

--- a/combine-counts/combine_star_counts.py
+++ b/combine-counts/combine_star_counts.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*-coding:utf-8 -*-
+"""
+@File    :   combine_star_counts.py
+@Time    :   2025/04/24
+@Author  :   Taylor Firman
+@Version :   0.1.0
+@Contact :   tfirman@fredhutch.org
+@Desc    :   Combine individual STAR counts into a single matrix for DESeq2
+"""
+
+import pandas as pd
+import os
+import argparse
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Combine STAR count matrices')
+    parser.add_argument('--input', nargs='+', required=True, help='Input gene count files from STAR')
+    parser.add_argument('--output', default='combined_counts_matrix.txt', help='Output combined matrix file')
+    parser.add_argument('--metadata', default='sample_metadata_template.txt', help='Output sample metadata template')
+    parser.add_argument('--count_column', type=int, default=2, 
+                        help='Which column to use (2=unstranded, 3=stranded forward, 4=stranded reverse)')
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+    
+    count_files = args.input
+    count_column = args.count_column
+    
+    # Extract sample names from file paths
+    sample_names = []
+    for file_path in count_files:
+        # Extract the base filename from the path
+        basename = os.path.basename(file_path)
+        # Extract the sample name before the first dot
+        sample_name = basename.split('.')[0]
+        sample_names.append(sample_name)
+    
+    print(f"Processing {len(count_files)} count files...")
+    print(f"Sample names extracted: {sample_names}")
+    
+    # Function to read STAR gene count file
+    def read_star_counts(file_path, sample_name, count_col):
+        # Skip the first 4 lines (summary statistics)
+        df = pd.read_csv(file_path, sep='\t', skiprows=4, header=None)
+        
+        # Select only gene ID column and the requested count column
+        df = df.iloc[:, [0, count_col-1]]
+        
+        # Name the columns
+        df.columns = ['gene_id', sample_name]
+        
+        return df
+    
+    # Read the first file to get the gene list
+    print(f"Reading first file: {os.path.basename(count_files[0])}")
+    combined = read_star_counts(count_files[0], sample_names[0], count_column)
+    
+    # Add the rest of the samples
+    if len(count_files) > 1:
+        for i in range(1, len(count_files)):
+            print(f"Reading file {i+1}/{len(count_files)}: {os.path.basename(count_files[i])}")
+            sample_counts = read_star_counts(count_files[i], sample_names[i], count_column)
+            combined = pd.merge(combined, sample_counts, on='gene_id')
+    
+    # Write out the combined matrix
+    print(f"Writing combined matrix to {args.output}...")
+    combined.to_csv(args.output, sep='\t', index=False)
+    
+    # Create a sample metadata template for DESeq2
+    metadata = pd.DataFrame({
+        'sample_id': sample_names,
+        'condition': ['condition'] * len(sample_names)
+    })
+    metadata.to_csv(args.metadata, sep='\t', index=False)
+    
+    # Print summary
+    print(f"Combined {len(sample_names)} samples into a single count matrix")
+    print(f"Total genes: {len(combined)}")
+    print("Output files:")
+    print(f"  - {args.output} (main counts matrix)")
+    print(f"  - {args.metadata} (template for DESeq2 sample metadata)")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
- FH user recently asked about actually adding DESeq2 to `ww-star-deseq2`.
- First need a custom script to combine gene counts into a single matrix.
- This image contains a python script that does that and will be used as another task at the end of `ww-star-deseq2`.

## Testing
- Built image locally and ran script locally, works as expected.