### PR TITLE
Fixing apt get install versions in rnaseqc

### DIFF
--- a/rnaseqc/Dockerfile_2.4.2
+++ b/rnaseqc/Dockerfile_2.4.2
@@ -17,8 +17,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Installing Java
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openjdk-17-jdk=17.0.12+7-2 \
-    ant=1.10.14-1 wget=1.24.5-1ubuntu2 r-base=4.4.1-1 ca-certificates-java=20240118 \
+    && OPENJDK_VERSION=$(apt-cache policy openjdk-17-jdk | grep Candidate | awk '{print $2}') \
+    && ANT_VERSION=$(apt-cache policy ant | grep Candidate | awk '{print $2}') \
+    && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+    && RBASE_VERSION=$(apt-cache policy r-base | grep Candidate | awk '{print $2}') \
+    && CACERT_VERSION=$(apt-cache policy ca-certificates-java | grep Candidate | awk '{print $2}') \
+    && apt-get install -y --no-install-recommends \
+    openjdk-17-jdk="${OPENJDK_VERSION}" \
+    ant="${ANT_VERSION}" \
+    wget="${WGET_VERSION}" \
+    r-base="${RBASE_VERSION}" \
+    ca-certificates-java="${CACERT_VERSION}" \
     && rm -rf /var/lib/apt/lists/* \
     && update-ca-certificates -f;
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64/

--- a/rnaseqc/Dockerfile_2.4.2
+++ b/rnaseqc/Dockerfile_2.4.2
@@ -15,6 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Setting environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Installing Java
 RUN apt-get update \
     && OPENJDK_VERSION=$(apt-cache policy openjdk-17-jdk | grep Candidate | awk '{print $2}') \

--- a/rnaseqc/Dockerfile_latest
+++ b/rnaseqc/Dockerfile_latest
@@ -17,8 +17,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Installing Java
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openjdk-17-jdk=17.0.12+7-2 \
-    ant=1.10.14-1 wget=1.24.5-1ubuntu2 r-base=4.4.1-1 ca-certificates-java=20240118 \
+    && OPENJDK_VERSION=$(apt-cache policy openjdk-17-jdk | grep Candidate | awk '{print $2}') \
+    && ANT_VERSION=$(apt-cache policy ant | grep Candidate | awk '{print $2}') \
+    && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+    && RBASE_VERSION=$(apt-cache policy r-base | grep Candidate | awk '{print $2}') \
+    && CACERT_VERSION=$(apt-cache policy ca-certificates-java | grep Candidate | awk '{print $2}') \
+    && apt-get install -y --no-install-recommends \
+    openjdk-17-jdk="${OPENJDK_VERSION}" \
+    ant="${ANT_VERSION}" \
+    wget="${WGET_VERSION}" \
+    r-base="${RBASE_VERSION}" \
+    ca-certificates-java="${CACERT_VERSION}" \
     && rm -rf /var/lib/apt/lists/* \
     && update-ca-certificates -f;
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64/

--- a/rnaseqc/Dockerfile_latest
+++ b/rnaseqc/Dockerfile_latest
@@ -15,6 +15,9 @@ LABEL org.opencontainers.image.licenses=MIT
 # Setting environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Installing Java
 RUN apt-get update \
     && OPENJDK_VERSION=$(apt-cache policy openjdk-17-jdk | grep Candidate | awk '{print $2}') \

--- a/sourmash/Dockerfile_4.8.2
+++ b/sourmash/Dockerfile_4.8.2
@@ -29,3 +29,4 @@ RUN sourmash --version
 
 # Set the default command
 ENTRYPOINT ["/bin/bash"]
+

--- a/sourmash/Dockerfile_latest
+++ b/sourmash/Dockerfile_latest
@@ -29,3 +29,4 @@ RUN sourmash --version
 
 # Set the default command
 ENTRYPOINT ["/bin/bash"]
+


### PR DESCRIPTION
## Description
- Fixing the versions of prerequisite packages in rnaseqc images.

## Testing
- Built locally, worked as expected.