### PR TITLE
Downsizing AnnotSV Docker Images

### DIFF
--- a/annotsv/Dockerfile_3.4.4
+++ b/annotsv/Dockerfile_3.4.4
@@ -41,7 +41,8 @@ RUN apt-get update \
 RUN wget -q -O annotsv.tar.gz https://github.com/lgmgeo/AnnotSV/archive/v3.4.4.tar.gz && tar -xzf annotsv.tar.gz
 WORKDIR /AnnotSV-3.4.4
 RUN make PREFIX=. install \
-  && make PREFIX=. install-human-annotation
+  && make PREFIX=. install-human-annotation \
+  && rm -rf share/AnnotSV/Annotations_Exomiser
 WORKDIR /
 
 ENV ANNOTSV=/AnnotSV-3.4.4

--- a/annotsv/Dockerfile_latest
+++ b/annotsv/Dockerfile_latest
@@ -41,7 +41,8 @@ RUN apt-get update \
 RUN wget -q -O annotsv.tar.gz https://github.com/lgmgeo/AnnotSV/archive/v3.4.4.tar.gz && tar -xzf annotsv.tar.gz
 WORKDIR /AnnotSV-3.4.4
 RUN make PREFIX=. install \
-  && make PREFIX=. install-human-annotation
+  && make PREFIX=. install-human-annotation \
+  && rm -rf share/AnnotSV/Annotations_Exomiser
 WORKDIR /
 
 ENV ANNOTSV=/AnnotSV-3.4.4

--- a/annotsv/README.md
+++ b/annotsv/README.md
@@ -69,7 +69,7 @@ apptainer run --bind /path/to/data:/data docker://getwilds/annotsv:latest \
 
 - `-SVinputFile`: Input VCF file containing structural variants
 - `-outputDir`: Directory for output files
-- `-genomeBuild`: Genome build (GRCh37/hg19 or GRCh38/hg38)
+- `-genomeBuild`: Genome build (GRCh37 or GRCh38)
 - `-SVminSize`: Minimum SV size to consider (default: 50bp)
 - `-includeCI`: Include confidence intervals in output
 - `-annotationsDir`: Directory containing annotation databases (pre-configured in container)
@@ -80,6 +80,11 @@ The container includes these pre-configured environment variables:
 
 - `ANNOTSV`: Points to the AnnotSV installation directory (`/AnnotSV-3.4.4`)
 - `PATH`: Includes the AnnotSV binary directory, allowing direct execution of `AnnotSV` command
+
+### Functionality Limitations
+
+- Exomiser reference data has been deleted from the image as it is way too big and isn't used frequently within the WILDS WDL ecosystem.
+- For use in Apptainer, we recommend sticking with the default promoter size of 500, as custom promoter sizes require writing to the container's file system (which frequently isn't allowed in Apptainer).
 
 ## Integration with WILDS
 


### PR DESCRIPTION
## Description
- Removing unnecessary Exomiser reference data from the AnnotSV images to save space
- Image is 2GB instead of 5GB, which is manageable
    - Could probably downsize even further if necessary, but would need to split by ref genome

## Related Issue
- Fixes #239

## Testing
- Built locally and successfully annotated a test vcf, exact same results as before