### PR TITLE
Adding bcftools to Delly Docker Image

### DIFF
--- a/delly/Dockerfile_1.2.9
+++ b/delly/Dockerfile_1.2.9
@@ -96,7 +96,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install minimal runtime dependencies
 RUN apt-get update \
   && LIBGOMP1_VERSION=$(apt-cache policy libgomp1 | grep Candidate | awk '{print $2}') \
-  && apt-get install -y --no-install-recommends libgomp1="${LIBGOMP1_VERSION}" \
+  && BCFTOOLS_VERSION=$(apt-cache policy bcftools | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  libgomp1="${LIBGOMP1_VERSION}" \
+  bcftools="${BCFTOOLS_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 # Create directory and copy binary

--- a/delly/Dockerfile_latest
+++ b/delly/Dockerfile_latest
@@ -96,7 +96,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install minimal runtime dependencies
 RUN apt-get update \
   && LIBGOMP1_VERSION=$(apt-cache policy libgomp1 | grep Candidate | awk '{print $2}') \
-  && apt-get install -y --no-install-recommends libgomp1="${LIBGOMP1_VERSION}" \
+  && BCFTOOLS_VERSION=$(apt-cache policy bcftools | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  libgomp1="${LIBGOMP1_VERSION}" \
+  bcftools="${BCFTOOLS_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 # Create directory and copy binary

--- a/delly/README.md
+++ b/delly/README.md
@@ -9,7 +9,7 @@ This directory contains Docker images for Delly, an integrated structural varian
 
 ## Image Details
 
-These Docker images are built from Ubuntu 22.04 and include a statically compiled Delly binary. The images use a multi-stage build process to minimize the final image size while ensuring all necessary dependencies are included. Delly uses paired-ends, split-reads and read-depth to sensitively and accurately delineate genomic rearrangements throughout the genome.
+These Docker images are built from Ubuntu 22.04 and include a statically compiled Delly binary with bcftools for BCF indexing and manipulation. The images use a multi-stage build process to minimize the final image size while ensuring all necessary dependencies are included. Delly uses paired-ends, split-reads and read-depth to sensitively and accurately delineate genomic rearrangements throughout the genome.
 
 ## Usage
 


### PR DESCRIPTION
## Description
- Totally spaced that we should include bcftools for vcf indexing.
- No Delly functionality change, just adding bcftools to the installation.

## Related Issue
- Related to #243 

## Testing
- Built locally and verified bcftools installation, looks good.