### PR TITLE
Adding ca-certificates to bcftools Docker image

### DIFF
--- a/bcftools/Dockerfile_1.11
+++ b/bcftools/Dockerfile_1.11
@@ -27,6 +27,7 @@ RUN apt-get update \
   && LIBLZMA_VERSION=$(apt-cache policy liblzma-dev | grep Candidate | awk '{print $2}') \
   && LIBSSL_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
   && LIBCURL4_VERSION=$(apt-cache policy libcurl4-gnutls-dev | grep Candidate | awk '{print $2}') \
+  && CERT_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   build-essential="${BE_VERSION}" \
   wget="${WGET_VERSION}" \
@@ -38,6 +39,7 @@ RUN apt-get update \
   liblzma-dev="${LIBLZMA_VERSION}" \
   libssl-dev="${LIBSSL_VERSION}" \
   libcurl4-gnutls-dev="${LIBCURL4_VERSION}" \
+  ca-certificates="${CERT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bcftools source code

--- a/bcftools/Dockerfile_1.19
+++ b/bcftools/Dockerfile_1.19
@@ -27,6 +27,7 @@ RUN apt-get update \
   && LIBLZMA_VERSION=$(apt-cache policy liblzma-dev | grep Candidate | awk '{print $2}') \
   && LIBSSL_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
   && LIBCURL4_VERSION=$(apt-cache policy libcurl4-gnutls-dev | grep Candidate | awk '{print $2}') \
+  && CERT_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   build-essential="${BE_VERSION}" \
   wget="${WGET_VERSION}" \
@@ -38,6 +39,7 @@ RUN apt-get update \
   liblzma-dev="${LIBLZMA_VERSION}" \
   libssl-dev="${LIBSSL_VERSION}" \
   libcurl4-gnutls-dev="${LIBCURL4_VERSION}" \
+  ca-certificates="${CERT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bcftools source code

--- a/bcftools/Dockerfile_latest
+++ b/bcftools/Dockerfile_latest
@@ -27,6 +27,7 @@ RUN apt-get update \
   && LIBLZMA_VERSION=$(apt-cache policy liblzma-dev | grep Candidate | awk '{print $2}') \
   && LIBSSL_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
   && LIBCURL4_VERSION=$(apt-cache policy libcurl4-gnutls-dev | grep Candidate | awk '{print $2}') \
+  && CERT_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   build-essential="${BE_VERSION}" \
   wget="${WGET_VERSION}" \
@@ -38,6 +39,7 @@ RUN apt-get update \
   liblzma-dev="${LIBLZMA_VERSION}" \
   libssl-dev="${LIBSSL_VERSION}" \
   libcurl4-gnutls-dev="${LIBCURL4_VERSION}" \
+  ca-certificates="${CERT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 # Pulling and extracting bcftools source code


### PR DESCRIPTION
## Description
- Discovered that vcf streaming was running into certificate issue during download.
- Needed to add `ca-certificates` to the `apt get` install list.

## Testing
- Tested locally, works great, even within the context of the `ww-testdata` WDL.