### PR TITLE
Adding GNU Parallel to the GATK image

### DIFF
--- a/gatk/Dockerfile_4.3.0.0
+++ b/gatk/Dockerfile_4.3.0.0
@@ -41,6 +41,7 @@ RUN apt-get update \
   && AUTOCONF_VERSION=$(apt-cache policy autoconf | grep Candidate | awk '{print $2}') \
   && AUTOMAKE_VERSION=$(apt-cache policy automake | grep Candidate | awk '{print $2}') \
   && LIBNCURSES_VERSION=$(apt-cache policy libncurses-dev | grep Candidate | awk '{print $2}') \
+  && PARALLEL_VERSION=$(apt-cache policy parallel | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   wget="${WGET_VERSION}" \
   unzip="${UNZIP_VERSION}" \
@@ -59,6 +60,7 @@ RUN apt-get update \
   autoconf="${AUTOCONF_VERSION}" \
   automake="${AUTOMAKE_VERSION}" \
   libncurses-dev="${LIBNCURSES_VERSION}" \
+  parallel="${PARALLEL_VERSION}" \
   && rm -rf /var/lib/apt/lists/* \
   && ln -sf /usr/bin/python3 /usr/bin/python
 

--- a/gatk/Dockerfile_4.6.1.0
+++ b/gatk/Dockerfile_4.6.1.0
@@ -41,6 +41,7 @@ RUN apt-get update \
   && AUTOCONF_VERSION=$(apt-cache policy autoconf | grep Candidate | awk '{print $2}') \
   && AUTOMAKE_VERSION=$(apt-cache policy automake | grep Candidate | awk '{print $2}') \
   && LIBNCURSES_VERSION=$(apt-cache policy libncurses-dev | grep Candidate | awk '{print $2}') \
+  && PARALLEL_VERSION=$(apt-cache policy parallel | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   wget="${WGET_VERSION}" \
   unzip="${UNZIP_VERSION}" \
@@ -59,6 +60,7 @@ RUN apt-get update \
   autoconf="${AUTOCONF_VERSION}" \
   automake="${AUTOMAKE_VERSION}" \
   libncurses-dev="${LIBNCURSES_VERSION}" \
+  parallel="${PARALLEL_VERSION}" \
   && rm -rf /var/lib/apt/lists/* \
   && ln -sf /usr/bin/python3 /usr/bin/python
 

--- a/gatk/Dockerfile_latest
+++ b/gatk/Dockerfile_latest
@@ -41,6 +41,7 @@ RUN apt-get update \
   && AUTOCONF_VERSION=$(apt-cache policy autoconf | grep Candidate | awk '{print $2}') \
   && AUTOMAKE_VERSION=$(apt-cache policy automake | grep Candidate | awk '{print $2}') \
   && LIBNCURSES_VERSION=$(apt-cache policy libncurses-dev | grep Candidate | awk '{print $2}') \
+  && PARALLEL_VERSION=$(apt-cache policy parallel | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   wget="${WGET_VERSION}" \
   unzip="${UNZIP_VERSION}" \
@@ -59,6 +60,7 @@ RUN apt-get update \
   autoconf="${AUTOCONF_VERSION}" \
   automake="${AUTOMAKE_VERSION}" \
   libncurses-dev="${LIBNCURSES_VERSION}" \
+  parallel="${PARALLEL_VERSION}" \
   && rm -rf /var/lib/apt/lists/* \
   && ln -sf /usr/bin/python3 /usr/bin/python
 

--- a/gatk/README.md
+++ b/gatk/README.md
@@ -17,6 +17,7 @@ These Docker images are built from Ubuntu 24.04 and include:
 - **htslib 1.20**: High-throughput sequencing library including bgzip and tabix utilities
 - **Java 17**: Required runtime environment for GATK
 - **Python 3**: For GATK workflow scripts and utilities
+- **GNU Parallel**: For parallel execution of tasks
 
 The images are designed to be comprehensive yet minimal, providing all essential tools for genomics analysis workflows.
 
@@ -88,7 +89,7 @@ apptainer run --bind /path/to/data:/data docker://getwilds/gatk:latest gatk Hapl
 
 ### **Optimization Tips**
 - Use interval lists for targeted sequencing to improve performance
-- Consider parallel processing for large cohorts
+- Consider parallel processing for large cohorts using GNU Parallel
 - Use appropriate Java memory settings with `--java-options`
 
 ## Security Features


### PR DESCRIPTION
## Description
- After testing the ww-leukemia pipeline, it became obvious that parallelization needs to occur for Mutect2 and HaplotypeCaller in order to complete analysis in a reasonable time.
- Unfortunately, scatter-gather techniques duplicate the rather large reference files, which is fine once or twice, but not 24 times like we want for this parallelization.
- To get around this, we'd like to implement the parallelization within a single task using the [GNU Parallel tool](https://www.gnu.org/software/parallel/parallel_examples.html).
- Just needed to add `parallel` to the `apt get` install list.

## Related Issue
- Fixes #253 

## Testing
- Built locally, works as expected!