### PR TITLE
Adding aws_signing_helper to awscli for IAM Authentication

### DIFF
--- a/awscli/Dockerfile_2.27.49
+++ b/awscli/Dockerfile_2.27.49
@@ -30,3 +30,8 @@ RUN apt-get update \
   && ./aws/install \
   && rm -rf awscliv2.zip aws \
   && rm -rf /var/lib/apt/lists/*
+
+# Install AWS Signing Helper
+RUN curl -o aws_signing_helper https://rolesanywhere.amazonaws.com/releases/1.2.0/X86_64/Linux/aws_signing_helper \
+  && chmod +x aws_signing_helper \
+  && mv aws_signing_helper /usr/local/bin/

--- a/awscli/Dockerfile_latest
+++ b/awscli/Dockerfile_latest
@@ -30,3 +30,8 @@ RUN apt-get update \
   && ./aws/install \
   && rm -rf awscliv2.zip aws \
   && rm -rf /var/lib/apt/lists/*
+
+# Install AWS Signing Helper
+RUN curl -o aws_signing_helper https://rolesanywhere.amazonaws.com/releases/1.2.0/X86_64/Linux/aws_signing_helper \
+  && chmod +x aws_signing_helper \
+  && mv aws_signing_helper /usr/local/bin/

--- a/awscli/README.md
+++ b/awscli/README.md
@@ -12,12 +12,13 @@ This directory contains Docker images for AWS CLI, the unified command-line inte
 These Docker images are built from Ubuntu Noble (24.04 LTS) base image and include:
 
 - AWS CLI v2.27.49 (pinned version) or latest: Command-line interface for Amazon Web Services
+- AWS Signing Helper v1.2.0: Certificate-based authentication helper for AWS IAM Roles Anywhere
 - samtools v1.19.2: For BAM/SAM file manipulation and filtering
 - curl: For downloading AWS CLI installer
 - unzip: For extracting AWS CLI installer
 - ca-certificates: For secure HTTPS connections
 
-The images are designed to be minimal and focused on providing AWS CLI functionality for accessing **public cloud datasets**, with additional samtools support for BAM file processing. This image is primarily intended for downloading publicly available bioinformatics datasets and performing basic filtering operations without requiring AWS credentials.
+The images are designed to be minimal and focused on providing AWS CLI functionality for accessing **public cloud datasets**, with additional samtools support for BAM file processing. The inclusion of AWS Signing Helper enables certificate-based authentication for more secure access to private AWS resources when needed.
 
 ## Usage
 
@@ -41,6 +42,57 @@ apptainer pull docker://getwilds/awscli:2.27.49
 
 # Alternatively, pull from GitHub Container Registry
 apptainer pull docker://ghcr.io/getwilds/awscli:latest
+```
+
+## Authentication Methods
+
+This image now supports multiple authentication methods:
+
+### 1. Public Data Access (No Authentication)
+
+**Recommended for most bioinformatics workflows**
+```bash
+# Download public data (no AWS credentials required)
+docker run --rm -v /path/to/data:/data getwilds/awscli:latest \
+  aws s3 sync --no-sign-request s3://gatk-test-data/wgs_bam/NA12878_20k_b37/ /data/
+```
+
+### 2. Certificate-Based Authentication (IAM Roles Anywhere)
+
+For secure access to private AWS resources using x.509 certificates:
+
+```bash
+# Mount certificates and configure AWS CLI to use signing helper
+docker run --rm \
+  -v /path/to/certs:/certs:ro \
+  -v /path/to/data:/data \
+  -e AWS_PROFILE=roles-anywhere \
+  getwilds/awscli:latest \
+  aws s3 ls s3://private-bucket/
+```
+
+Example AWS CLI configuration for certificate authentication:
+```ini
+# ~/.aws/config
+[profile roles-anywhere]
+credential_process = aws_signing_helper credential-process \
+  --certificate /certs/client.crt \
+  --private-key /certs/client.key \
+  --trust-anchor-arn arn:aws:rolesanywhere:region:account:trust-anchor/ta-id \
+  --profile-arn arn:aws:rolesanywhere:region:account:profile/profile-id \
+  --role-arn arn:aws:iam::account:role/role-name
+```
+
+### 3. Traditional IAM Credentials (Not Recommended for Containers)
+
+If you must use traditional AWS credentials, mount them carefully:
+```bash
+# Use with caution - not recommended for production
+docker run --rm \
+  -v ~/.aws:/root/.aws:ro \
+  -v /path/to/data:/data \
+  getwilds/awscli:latest \
+  aws s3 ls s3://private-bucket/
 ```
 
 ### Example Commands (Public Data Focus)
@@ -121,7 +173,8 @@ The AWS CLI Docker images include:
 - Minimal package installation to reduce attack surface
 - Use of `--no-install-recommends` to minimize dependencies
 - Proper cleanup of package caches and temporary files
-- **Optimized for public data access** - no credential management required
+- **Support for certificate-based authentication** - more secure than traditional access keys
+- **Optimized for public data access** - no credential management required for most use cases
 
 ### Security Recommendations
 
@@ -130,9 +183,16 @@ The AWS CLI Docker images include:
 - Always use the `--no-sign-request` flag for public S3 buckets
 - No AWS credentials needed - safer and simpler
 
-**Not Recommended: Private Data Access**
+**Acceptable: Certificate-Based Authentication**
+- Use AWS IAM Roles Anywhere with x.509 certificates for private data access
+- Certificates provide better security than long-lived access keys
+- Mount certificates as read-only volumes
+- Consider using temporary certificates when possible
+
+**Not Recommended: Traditional IAM Credentials**
 - Avoid mounting AWS credentials (`~/.aws`) into containers when possible
-- For private S3 operations, consider installing AWS CLI directly on your host system
+- If you must use traditional credentials, ensure proper file permissions and use read-only mounts
+- Consider using AWS IAM roles for service accounts (IRSA) in Kubernetes environments instead
 
 ### Security Scanning and CVEs
 
@@ -157,6 +217,39 @@ aws s3 [command] --no-sign-request s3://public-bucket/path/
 - `s3://encode-public/` - ENCODE consortium data
 - `s3://1000genomes/` - 1000 Genomes Project data
 
+### Certificate-Based Authentication Setup
+
+To use AWS IAM Roles Anywhere with certificates:
+
+1. **Set up IAM Roles Anywhere** in your AWS account
+2. **Create a trust anchor** with your Certificate Authority
+3. **Create a profile** that maps certificates to IAM roles
+4. **Configure AWS CLI** to use the signing helper:
+
+```bash
+# Create AWS config file
+mkdir -p ~/.aws
+cat > ~/.aws/config << EOF
+[profile roles-anywhere]
+credential_process = aws_signing_helper credential-process \\
+  --certificate /path/to/client.crt \\
+  --private-key /path/to/client.key \\
+  --trust-anchor-arn arn:aws:rolesanywhere:region:account:trust-anchor/ta-id \\
+  --profile-arn arn:aws:rolesanywhere:region:account:profile/profile-id \\
+  --role-arn arn:aws:iam::account:role/role-name
+EOF
+```
+
+5. **Use the profile** with the container:
+```bash
+docker run --rm \
+  -v ~/.aws:/root/.aws:ro \
+  -v /path/to/certs:/certs:ro \
+  -e AWS_PROFILE=roles-anywhere \
+  getwilds/awscli:latest \
+  aws s3 ls
+```
+
 ## Dockerfile Structure
 
 The Dockerfile follows these main steps:
@@ -166,7 +259,8 @@ The Dockerfile follows these main steps:
 3. Sets shell options for robust error handling (`pipefail`)
 4. Dynamically determines and pins package versions for reproducibility
 5. Installs AWS CLI v2 from official AWS distribution
-6. Cleans up installation artifacts to minimize image size
+6. Installs AWS Signing Helper from official AWS Roles Anywhere releases
+7. Cleans up installation artifacts to minimize image size
 
 ## Source Repository
 


### PR DESCRIPTION
## Description
- While creating the [`ww-aws` WILDS WDL module](https://github.com/getwilds/wilds-wdl-library/pull/90), it came to our attention that `aws_signing_helper` will need to be installed to this image in order for IAM Roles Anywhere credentials to function properly.
- Still working on how to incorporate this into a WDL, but the image itself should work as expected now.

## Related Issue
- Fixes #256 

## Testing
- Built locally, installation works as expected.