### PR TITLE
Adding Pasilla package to DESeq2 image for example count data

### DIFF
--- a/deseq2/Dockerfile_1.40.2
+++ b/deseq2/Dockerfile_1.40.2
@@ -30,7 +30,7 @@ ENV R_LIBS_USER=/usr/local/lib/R/site-library
 ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
 
 # Install required R packages
-RUN R -e "BiocManager::install(c('DESeq2', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE)"
+RUN R -e "BiocManager::install(c('DESeq2', 'pasilla', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE, ask=FALSE, dependencies=TRUE)"
 
 # Copy the DESeq2 analysis script to the container
 COPY deseq2/deseq2_analysis.R /deseq2_analysis.R

--- a/deseq2/Dockerfile_latest
+++ b/deseq2/Dockerfile_latest
@@ -30,7 +30,7 @@ ENV R_LIBS_USER=/usr/local/lib/R/site-library
 ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
 
 # Install required R packages
-RUN R -e "BiocManager::install(c('DESeq2', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE)"
+RUN R -e "BiocManager::install(c('DESeq2', 'pasilla', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE, ask=FALSE, dependencies=TRUE)"
 
 # Copy the DESeq2 analysis script to the container
 COPY deseq2/deseq2_analysis.R /deseq2_analysis.R

--- a/deseq2/README.md
+++ b/deseq2/README.md
@@ -12,12 +12,13 @@ This directory contains Docker images for DESeq2, a Bioconductor package for dif
 These Docker images are built from the Bioconductor base image and include:
 
 - DESeq2 v1.40.2: A package for differential expression analysis of RNA-seq count data
+- pasilla: Example RNA-seq dataset from Drosophila for testing and tutorials
 - apeglm: For LFC shrinkage estimation
 - pheatmap & RColorBrewer: For visualization of differential expression results
 - optparse, ggplot2, dplyr: For command-line interface and data processing
 - A ready-to-use analysis script for standard differential expression workflows
 
-The images are designed to provide a comprehensive environment for RNA-seq differential expression analysis with DESeq2 methodology.
+The images are designed to provide a comprehensive environment for RNA-seq differential expression analysis with DESeq2 methodology, including example data for testing and learning purposes.
 
 ## Usage
 
@@ -89,6 +90,15 @@ The analysis produces the following outputs:
 5. `*_volcano.pdf`: Volcano plot of differential expression results
 6. `*_heatmap.pdf`: Heatmap of top differentially expressed genes
 
+## Example Data
+
+The image includes the `pasilla` dataset, which contains RNA-seq count data from a study on the pasilla gene in Drosophila. This dataset is useful for:
+
+- Testing DESeq2 workflows
+- Learning differential expression analysis
+- Validating analysis pipelines
+- Following DESeq2 tutorials and vignettes
+
 ## Security Features
 
 The DESeq2 Docker images include:
@@ -112,7 +122,7 @@ The Dockerfile follows these main steps:
 
 1. Uses Bioconductor RELEASE_3_17 as the base image
 2. Adds metadata labels for documentation and attribution
-3. Installs DESeq2 and related R packages
+3. Installs DESeq2, pasilla example data, and related R packages
 4. Installs system dependencies with version pinning
 5. Adds the analysis script and makes it executable
 6. Sets up a working directory for data analysis


### PR DESCRIPTION
## Description
- During the process of incorporating a DESeq2 WILDS WDL module, it became necessary to identify test count data.
- Bioconductor has a package called [`pasilla`](https://bioconductor.org/packages/release/data/experiment/html/pasilla.html) that contain [this type of example data](https://introtogenomics.readthedocs.io/en/latest/2021.11.11.DeseqTutorial.html) and should be included in the DESeq2 WILDS Docker image.

## Related Issue
- Fixes #261 

## Testing
- Built locally and successfully loaded and processed the `pasilla` test data.