### PR TITLE
Adding DESeq2/Pasilla test data generation script

### DIFF
--- a/deseq2/Dockerfile_1.40.2
+++ b/deseq2/Dockerfile_1.40.2
@@ -32,9 +32,10 @@ ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/libr
 # Install required R packages
 RUN R -e "BiocManager::install(c('DESeq2', 'pasilla', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE, ask=FALSE, dependencies=TRUE)"
 
-# Copy the DESeq2 analysis script to the container
+# Copy the DESeq2 analysis scripts to the container
 COPY deseq2/deseq2_analysis.R /deseq2_analysis.R
-RUN chmod +x /deseq2_analysis.R
+COPY deseq2/generate_pasilla_counts.R /generate_pasilla_counts.R
+RUN chmod +x /deseq2_analysis.R /generate_pasilla_counts.R
 
 # Set working directory
 WORKDIR /data

--- a/deseq2/Dockerfile_1.40.2
+++ b/deseq2/Dockerfile_1.40.2
@@ -33,9 +33,9 @@ ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/libr
 RUN R -e "BiocManager::install(c('DESeq2', 'pasilla', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE, ask=FALSE, dependencies=TRUE)"
 
 # Copy the DESeq2 analysis scripts to the container
-COPY deseq2/deseq2_analysis.R /deseq2_analysis.R
-COPY deseq2/generate_pasilla_counts.R /generate_pasilla_counts.R
-RUN chmod +x /deseq2_analysis.R /generate_pasilla_counts.R
+COPY deseq2/deseq2_analysis.R /usr/local/bin/deseq2_analysis.R
+COPY deseq2/generate_pasilla_counts.R /usr/local/bin/generate_pasilla_counts.R
+RUN chmod +x /usr/local/bin/deseq2_analysis.R /usr/local/bin/generate_pasilla_counts.R
 
 # Set working directory
 WORKDIR /data

--- a/deseq2/Dockerfile_latest
+++ b/deseq2/Dockerfile_latest
@@ -32,9 +32,10 @@ ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/libr
 # Install required R packages
 RUN R -e "BiocManager::install(c('DESeq2', 'pasilla', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE, ask=FALSE, dependencies=TRUE)"
 
-# Copy the DESeq2 analysis script to the container
+# Copy the DESeq2 analysis scripts to the container
 COPY deseq2/deseq2_analysis.R /deseq2_analysis.R
-RUN chmod +x /deseq2_analysis.R
+COPY deseq2/generate_pasilla_counts.R /generate_pasilla_counts.R
+RUN chmod +x /deseq2_analysis.R /generate_pasilla_counts.R
 
 # Set working directory
 WORKDIR /data

--- a/deseq2/Dockerfile_latest
+++ b/deseq2/Dockerfile_latest
@@ -33,9 +33,9 @@ ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/libr
 RUN R -e "BiocManager::install(c('DESeq2', 'pasilla', 'ggplot2', 'pheatmap', 'optparse', 'RColorBrewer'), update=FALSE, ask=FALSE, dependencies=TRUE)"
 
 # Copy the DESeq2 analysis scripts to the container
-COPY deseq2/deseq2_analysis.R /deseq2_analysis.R
-COPY deseq2/generate_pasilla_counts.R /generate_pasilla_counts.R
-RUN chmod +x /deseq2_analysis.R /generate_pasilla_counts.R
+COPY deseq2/deseq2_analysis.R /usr/local/bin/deseq2_analysis.R
+COPY deseq2/generate_pasilla_counts.R /usr/local/bin/generate_pasilla_counts.R
+RUN chmod +x /usr/local/bin/deseq2_analysis.R /usr/local/bin/generate_pasilla_counts.R
 
 # Set working directory
 WORKDIR /data

--- a/deseq2/README.md
+++ b/deseq2/README.md
@@ -77,17 +77,17 @@ apptainer run --bind /path/to/data:/data docker://getwilds/deseq2:latest Rscript
 # Generate test count matrices using the pasilla dataset
 docker run --rm -v /path/to/output:/data getwilds/deseq2:latest \
   generate_pasilla_counts.R \
-  --n-samples 7 \
-  --n-genes 10000 \
-  --condition-name condition \
-  --output-prefix /data/test_data
+  --nsamples 7 \
+  --ngenes 10000 \
+  --condition condition \
+  --prefix /data/test_data
 
 # Generate smaller test dataset
 docker run --rm -v /path/to/output:/data getwilds/deseq2:latest \
   generate_pasilla_counts.R \
-  --n-samples 4 \
-  --n-genes 5000 \
-  --output-prefix /data/small_test
+  --nsamples 4 \
+  --ngenes 5000 \
+  --prefix /data/small_test
 ```
 
 ### Script Parameters
@@ -107,10 +107,10 @@ The included `deseq2_analysis.R` script accepts the following parameters:
 
 The included `generate_pasilla_counts.R` script accepts the following parameters:
 
-- `--n-samples`: Number of samples to include (default: 7, max: 7 for pasilla dataset)
-- `--n-genes`: Approximate number of genes to include (default: 10000)
-- `--condition-name`: Name for the condition column in metadata (default: "condition")
-- `--output-prefix`: Prefix for output files (default: "pasilla")
+- `--nsamples`: Number of samples to include (default: 7, max: 7 for pasilla dataset)
+- `--ngenes`: Approximate number of genes to include (default: 10000)
+- `--condition`: Name for the condition column in metadata (default: "condition")
+- `--prefix`: Prefix for output files (default: "pasilla")
 
 ### Outputs
 

--- a/deseq2/README.md
+++ b/deseq2/README.md
@@ -17,6 +17,7 @@ These Docker images are built from the Bioconductor base image and include:
 - pheatmap & RColorBrewer: For visualization of differential expression results
 - optparse, ggplot2, dplyr: For command-line interface and data processing
 - A ready-to-use analysis script for standard differential expression workflows
+- A test data generation script for creating DESeq2-compatible datasets
 
 The images are designed to provide a comprehensive environment for RNA-seq differential expression analysis with DESeq2 methodology, including example data for testing and learning purposes.
 
@@ -46,6 +47,8 @@ apptainer pull docker://ghcr.io/getwilds/deseq2:latest
 
 ### Example Commands
 
+#### Running DESeq2 Analysis
+
 ```bash
 # Running DESeq2 analysis with default parameters
 docker run --rm -v /path/to/data:/data getwilds/deseq2:latest Rscript /deseq2_analysis.R \
@@ -68,7 +71,28 @@ apptainer run --bind /path/to/data:/data docker://getwilds/deseq2:latest Rscript
   --output_prefix=/data/results
 ```
 
+#### Generating Test Data
+
+```bash
+# Generate test count matrices using the pasilla dataset
+docker run --rm -v /path/to/output:/data getwilds/deseq2:latest \
+  generate_pasilla_counts.R \
+  --n-samples 7 \
+  --n-genes 10000 \
+  --condition-name condition \
+  --output-prefix /data/test_data
+
+# Generate smaller test dataset
+docker run --rm -v /path/to/output:/data getwilds/deseq2:latest \
+  generate_pasilla_counts.R \
+  --n-samples 4 \
+  --n-genes 5000 \
+  --output-prefix /data/small_test
+```
+
 ### Script Parameters
+
+#### DESeq2 Analysis Script (`deseq2_analysis.R`)
 
 The included `deseq2_analysis.R` script accepts the following parameters:
 
@@ -79,7 +103,18 @@ The included `deseq2_analysis.R` script accepts the following parameters:
 - `--contrast`: Contrast to use in format: condition,treatment,control (default: infer from condition_column)
 - `--output_prefix`: Prefix for output files (default: "deseq2_results")
 
+#### Test Data Generation Script (`generate_pasilla_counts.R`)
+
+The included `generate_pasilla_counts.R` script accepts the following parameters:
+
+- `--n-samples`: Number of samples to include (default: 7, max: 7 for pasilla dataset)
+- `--n-genes`: Approximate number of genes to include (default: 10000)
+- `--condition-name`: Name for the condition column in metadata (default: "condition")
+- `--output-prefix`: Prefix for output files (default: "pasilla")
+
 ### Outputs
+
+#### DESeq2 Analysis Outputs
 
 The analysis produces the following outputs:
 
@@ -90,6 +125,14 @@ The analysis produces the following outputs:
 5. `*_volcano.pdf`: Volcano plot of differential expression results
 6. `*_heatmap.pdf`: Heatmap of top differentially expressed genes
 
+#### Test Data Generation Outputs
+
+The test data generation produces the following outputs:
+
+1. `*_counts_matrix.txt`: Count matrix with genes as rows and samples as columns
+2. `*_sample_metadata.txt`: Sample metadata file with conditions and sample information
+3. `*_gene_info.txt`: Gene annotation information including gene IDs
+
 ## Example Data
 
 The image includes the `pasilla` dataset, which contains RNA-seq count data from a study on the pasilla gene in Drosophila. This dataset is useful for:
@@ -98,6 +141,9 @@ The image includes the `pasilla` dataset, which contains RNA-seq count data from
 - Learning differential expression analysis
 - Validating analysis pipelines
 - Following DESeq2 tutorials and vignettes
+- Generating customizable test datasets for workflow development
+
+The `generate_pasilla_counts.R` script allows you to create subsets of this data with varying numbers of samples and genes, making it ideal for testing workflows with different data sizes.
 
 ## Security Features
 
@@ -124,7 +170,7 @@ The Dockerfile follows these main steps:
 2. Adds metadata labels for documentation and attribution
 3. Installs DESeq2, pasilla example data, and related R packages
 4. Installs system dependencies with version pinning
-5. Adds the analysis script and makes it executable
+5. Adds the analysis and test data generation scripts and makes them executable
 6. Sets up a working directory for data analysis
 
 ## Source Repository

--- a/deseq2/generate_pasilla_counts.R
+++ b/deseq2/generate_pasilla_counts.R
@@ -1,0 +1,188 @@
+#!/usr/bin/env Rscript
+
+# Generate DESeq2 test count matrices and metadata using the pasilla Bioconductor dataset
+# Author: WILDS Team
+# Description: Creates count matrix, sample metadata, and gene info files for testing
+
+# Load required libraries
+suppressPackageStartupMessages({
+    library(optparse)
+    library(pasilla)
+    library(DESeq2)
+})
+
+# Define command line options
+option_list <- list(
+    make_option(c("--n-samples"), type = "integer", default = 7,
+                help = "Number of samples to include (default: 7, max: 7 for pasilla dataset)"),
+    make_option(c("--n-genes"), type = "integer", default = 10000,
+                help = "Approximate number of genes to include (will select top expressed genes)"),
+    make_option(c("--condition-name"), type = "character", default = "condition",
+                help = "Name for the condition column in metadata"),
+    make_option(c("--output-prefix"), type = "character", default = "pasilla",
+                help = "Prefix for output files"),
+    make_option(c("-h", "--help"), action = "store_true", default = FALSE,
+                help = "Show this help message and exit")
+)
+
+# Parse command line arguments
+opt_parser <- OptionParser(option_list = option_list,
+                          description = "Generate DESeq2 test data from pasilla dataset")
+opt <- parse_args(opt_parser)
+
+# Show help if requested
+if (opt$help) {
+    print_help(opt_parser)
+    quit(status = 0)
+}
+
+# Main execution
+tryCatch({
+    cat("=== Generating pasilla test data ===\n")
+    cat("Parameters:\n")
+    cat("  Samples:", opt$`n-samples`, "\n")
+    cat("  Genes:", opt$`n-genes`, "\n")
+    cat("  Condition column:", opt$`condition-name`, "\n")
+    cat("  Output prefix:", opt$`output-prefix`, "\n\n")
+    
+    # Get the actual pasilla data files
+    count_file <- system.file("extdata", "pasilla_gene_counts.tsv", package = "pasilla")
+    sample_file <- system.file("extdata", "pasilla_sample_annotation.csv", package = "pasilla")
+    
+    cat("Loading pasilla data from:\n")
+    cat("Count file:", count_file, "\n")
+    cat("Sample file:", sample_file, "\n\n")
+    
+    # Read the count matrix and sample data
+    count_data <- read.table(count_file, header = TRUE, row.names = 1, sep = "\t")
+    sample_data <- read.csv(sample_file, header = TRUE, row.names = 1)
+    
+    cat("Original data dimensions:\n")
+    cat("Genes:", nrow(count_data), "\n")
+    cat("Samples:", ncol(count_data), "\n\n")
+    
+    # Remove 'fb' suffix from sample metadata row names to match count data
+    rownames(sample_data) <- gsub("fb$", "", rownames(sample_data))
+
+    # Make sure sample names match between count data and metadata
+    common_samples <- intersect(colnames(count_data), rownames(sample_data))
+    count_data <- count_data[, common_samples]
+    sample_data <- sample_data[common_samples, ]
+    
+    # Limit to requested number of samples
+    n_samples_requested <- opt$`n-samples`
+    if (n_samples_requested > ncol(count_data)) {
+        n_samples_requested <- ncol(count_data)
+        cat("Warning: Requested", opt$`n-samples`, "samples, but only", ncol(count_data), "available\n")
+    }
+    
+    # Select samples (ensure we have both conditions represented)
+    untreated_samples <- rownames(sample_data)[sample_data$condition == "untreated"]
+    treated_samples <- rownames(sample_data)[sample_data$condition == "treated"]
+    
+    # Take roughly equal numbers from each condition
+    n_untreated <- ceiling(n_samples_requested / 2)
+    n_treated <- n_samples_requested - n_untreated
+    
+    # Adjust if we don't have enough samples of one type
+    if (n_untreated > length(untreated_samples)) {
+        n_untreated <- length(untreated_samples)
+        n_treated <- n_samples_requested - n_untreated
+    }
+    if (n_treated > length(treated_samples)) {
+        n_treated <- length(treated_samples)
+        n_untreated <- n_samples_requested - n_treated
+    }
+    
+    selected_samples <- c(
+        untreated_samples[1:n_untreated],
+        treated_samples[1:n_treated]
+    )
+    
+    # Subset data
+    count_data <- count_data[, selected_samples]
+    sample_data <- sample_data[selected_samples, ]
+    
+    # Select top expressed genes
+    n_genes_requested <- opt$`n-genes`
+    if (n_genes_requested > nrow(count_data)) {
+        n_genes_requested <- nrow(count_data)
+        cat("Warning: Requested", opt$`n-genes`, "genes, but only", nrow(count_data), "available\n")
+    }
+    
+    # Calculate mean counts per gene and select top expressed
+    gene_means <- rowMeans(count_data)
+    top_genes <- order(gene_means, decreasing = TRUE)[1:n_genes_requested]
+    
+    count_data <- count_data[top_genes, ]
+    
+    # Create clean sample metadata
+    metadata <- data.frame(
+        sample_name = colnames(count_data),
+        condition = as.character(sample_data$condition),
+        type = as.character(sample_data$type),
+        stringsAsFactors = FALSE
+    )
+    
+    # Rename condition column if requested
+    condition_col_name <- opt$`condition-name`
+    if (condition_col_name != "condition") {
+        names(metadata)[names(metadata) == "condition"] <- condition_col_name
+    }
+    
+    # Generate output filenames
+    counts_file <- paste0(opt$`output-prefix`, "_counts_matrix.txt")
+    metadata_file <- paste0(opt$`output-prefix`, "_sample_metadata.txt")
+    gene_info_file <- paste0(opt$`output-prefix`, "_gene_info.txt")
+    
+    # Write count matrix (genes as rows, samples as columns)
+    # Add gene names as first column
+    count_output <- cbind(
+        gene_id = rownames(count_data),
+        as.data.frame(count_data)
+    )
+    write.table(count_output, 
+                file = counts_file, 
+                sep = "\t", 
+                row.names = FALSE, 
+                col.names = TRUE,
+                quote = FALSE)
+    
+    # Write sample metadata
+    write.table(metadata, 
+                file = metadata_file, 
+                sep = "\t", 
+                row.names = FALSE, 
+                col.names = TRUE,
+                quote = FALSE)
+    
+    # Write gene information (simpler since we don't have detailed gene data)
+    gene_info <- data.frame(
+        gene_id = rownames(count_data),
+        gene_name = rownames(count_data),  # Use gene ID as name since we don't have symbols
+        stringsAsFactors = FALSE
+    )
+    write.table(gene_info, 
+                file = gene_info_file, 
+                sep = "\t", 
+                row.names = FALSE, 
+                col.names = TRUE,
+                quote = FALSE)
+    
+    # Print summary
+    cat("\n=== Generated pasilla test data ===\n")
+    cat("Files created:\n")
+    cat("  Count matrix:", counts_file, "\n")
+    cat("  Sample metadata:", metadata_file, "\n")
+    cat("  Gene info:", gene_info_file, "\n\n")
+    cat("Data summary:\n")
+    cat("  Samples:", ncol(count_data), "\n")
+    cat("  Genes:", nrow(count_data), "\n")
+    cat("  Conditions:", paste(unique(metadata[[condition_col_name]]), collapse = ", "), "\n")
+    cat("\nScript completed successfully!\n")
+
+}, error = function(e) {
+    cat("Error occurred during execution:\n")
+    cat(conditionMessage(e), "\n")
+    quit(status = 1)
+})

--- a/deseq2/generate_pasilla_counts.R
+++ b/deseq2/generate_pasilla_counts.R
@@ -13,16 +13,14 @@ suppressPackageStartupMessages({
 
 # Define command line options
 option_list <- list(
-    make_option(c("--n-samples"), type = "integer", default = 7,
+    make_option(c("-n", "--nsamples"), type = "integer", default = 7,
                 help = "Number of samples to include (default: 7, max: 7 for pasilla dataset)"),
-    make_option(c("--n-genes"), type = "integer", default = 10000,
+    make_option(c("-g", "--ngenes"), type = "integer", default = 10000,
                 help = "Approximate number of genes to include (will select top expressed genes)"),
-    make_option(c("--condition-name"), type = "character", default = "condition",
+    make_option(c("-c", "--condition"), type = "character", default = "condition",
                 help = "Name for the condition column in metadata"),
-    make_option(c("--output-prefix"), type = "character", default = "pasilla",
-                help = "Prefix for output files"),
-    make_option(c("-h", "--help"), action = "store_true", default = FALSE,
-                help = "Show this help message and exit")
+    make_option(c("-p", "--prefix"), type = "character", default = "pasilla",
+                help = "Prefix for output files")
 )
 
 # Parse command line arguments
@@ -30,20 +28,14 @@ opt_parser <- OptionParser(option_list = option_list,
                           description = "Generate DESeq2 test data from pasilla dataset")
 opt <- parse_args(opt_parser)
 
-# Show help if requested
-if (opt$help) {
-    print_help(opt_parser)
-    quit(status = 0)
-}
-
 # Main execution
 tryCatch({
     cat("=== Generating pasilla test data ===\n")
     cat("Parameters:\n")
-    cat("  Samples:", opt$`n-samples`, "\n")
-    cat("  Genes:", opt$`n-genes`, "\n")
-    cat("  Condition column:", opt$`condition-name`, "\n")
-    cat("  Output prefix:", opt$`output-prefix`, "\n\n")
+    cat("  Samples:", opt$nsamples, "\n")
+    cat("  Genes:", opt$ngenes, "\n")
+    cat("  Condition column:", opt$condition, "\n")
+    cat("  Output prefix:", opt$prefix, "\n\n")
     
     # Get the actual pasilla data files
     count_file <- system.file("extdata", "pasilla_gene_counts.tsv", package = "pasilla")
@@ -70,10 +62,10 @@ tryCatch({
     sample_data <- sample_data[common_samples, ]
     
     # Limit to requested number of samples
-    n_samples_requested <- opt$`n-samples`
+    n_samples_requested <- opt$nsamples
     if (n_samples_requested > ncol(count_data)) {
         n_samples_requested <- ncol(count_data)
-        cat("Warning: Requested", opt$`n-samples`, "samples, but only", ncol(count_data), "available\n")
+        cat("Warning: Requested", opt$nsamples, "samples, but only", ncol(count_data), "available\n")
     }
     
     # Select samples (ensure we have both conditions represented)
@@ -104,10 +96,10 @@ tryCatch({
     sample_data <- sample_data[selected_samples, ]
     
     # Select top expressed genes
-    n_genes_requested <- opt$`n-genes`
+    n_genes_requested <- opt$ngenes
     if (n_genes_requested > nrow(count_data)) {
         n_genes_requested <- nrow(count_data)
-        cat("Warning: Requested", opt$`n-genes`, "genes, but only", nrow(count_data), "available\n")
+        cat("Warning: Requested", opt$ngenes, "genes, but only", nrow(count_data), "available\n")
     }
     
     # Calculate mean counts per gene and select top expressed
@@ -125,15 +117,15 @@ tryCatch({
     )
     
     # Rename condition column if requested
-    condition_col_name <- opt$`condition-name`
+    condition_col_name <- opt$condition
     if (condition_col_name != "condition") {
         names(metadata)[names(metadata) == "condition"] <- condition_col_name
     }
     
     # Generate output filenames
-    counts_file <- paste0(opt$`output-prefix`, "_counts_matrix.txt")
-    metadata_file <- paste0(opt$`output-prefix`, "_sample_metadata.txt")
-    gene_info_file <- paste0(opt$`output-prefix`, "_gene_info.txt")
+    counts_file <- paste0(opt$prefix, "_counts_matrix.txt")
+    metadata_file <- paste0(opt$prefix, "_sample_metadata.txt")
+    gene_info_file <- paste0(opt$prefix, "_gene_info.txt")
     
     # Write count matrix (genes as rows, samples as columns)
     # Add gene names as first column


### PR DESCRIPTION
## Description
- While troubleshooting test data generation within a WDL task, it became clear that embedding an R script in the Docker image itself might be the easiest way to execute the analysis, i.e. `EOF` is a hassle.
- Also moved the two R scripts to the `/usr/local/bin/` directory for easier execution from anywhere.
- Updated the README accordingly as well.

## Related Issue
- Further addresses #261 

## Testing
- Built locally and ran the script, works as expected.