### PR TITLE
Adding necessary R libraries to the CNVkit Docker image

### DIFF
--- a/cnvkit/Dockerfile_0.9.10
+++ b/cnvkit/Dockerfile_0.9.10
@@ -56,6 +56,10 @@ RUN pip install --no-cache-dir \
     "numpy<1.25" \
     cnvkit==0.9.10
 
+# Install R packages required by CNVkit
+RUN R -e "install.packages(c('BiocManager', 'ggplot2', 'gridExtra', 'RColorBrewer'))" && \
+    R -e "BiocManager::install(c('DNAcopy', 'PSCBS', 'GenomicRanges', 'IRanges'))"
+
 # Switch to non-root user
 USER cnvkit
 

--- a/cnvkit/Dockerfile_latest
+++ b/cnvkit/Dockerfile_latest
@@ -56,6 +56,10 @@ RUN pip install --no-cache-dir \
     "numpy<1.25" \
     cnvkit==0.9.10
 
+# Install R packages required by CNVkit
+RUN R -e "install.packages(c('BiocManager', 'ggplot2', 'gridExtra', 'RColorBrewer'))" && \
+    R -e "BiocManager::install(c('DNAcopy', 'PSCBS', 'GenomicRanges', 'IRanges'))"
+
 # Switch to non-root user
 USER cnvkit
 

--- a/cnvkit/README.md
+++ b/cnvkit/README.md
@@ -14,6 +14,7 @@ These Docker images are built from Python slim base image and include:
 - Python 3.10: The core programming language (optimized for CNVkit compatibility)
 - CNVkit 0.9.10: A Python library and command-line software toolkit for detecting copy number variants and alterations from high-throughput sequencing
 - R base: Required for certain CNVkit statistical functions
+- R packages: Essential Bioconductor and CRAN packages (DNAcopy, PSCBS, GenomicRanges, IRanges, ggplot2, gridExtra, RColorBrewer, BiocManager)
 - Build tools: Essential compilation tools for native dependencies
 
 The images are designed to be secure and reliable while including all necessary components for CNVkit analysis of genomic data.
@@ -96,11 +97,12 @@ The Dockerfile follows these main steps:
 1. Uses Python 3.10-slim as the base image for optimal compatibility
 2. Adds metadata labels for documentation and attribution
 3. Sets environment variables for Python optimization
-4. Installs system dependencies (R, build tools, BLAS/LAPACK libraries)
+4. Installs system dependencies (R, build tools, BLAS/LAPACK libraries) with pinned versions
 5. Creates a non-root user for security
-6. Installs CNVkit 0.9.10 with compatible dependency versions
-7. Configures health checks and default command
-8. Switches to non-root user execution
+6. Installs CNVkit 0.9.10 with compatible dependency versions (Cython <3.0, NumPy <1.25)
+7. Installs essential R packages for CNVkit functionality
+8. Configures health checks and default command
+9. Switches to non-root user execution
 
 ## Source Repository
 


### PR DESCRIPTION
## Description
- Adding necessary R libraries for full CNVkit analysis.
- Updating the README accordingly as well.

## Testing
- Successfully built locally and ran the entire `ww-cnvkit` WDL test workflow with it, works as expected.