### PR TITLE
Reduce Docker Scout size limit in Build-and-Push GHA

### DIFF
--- a/.github/scripts/docker_update.py
+++ b/.github/scripts/docker_update.py
@@ -43,7 +43,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger("docker-update")
 
-# Size limit for Docker Scout scanning (5GB in bytes)
+# Size limit for Docker Scout scanning (4GB in bytes)
 DOCKER_SCOUT_SIZE_LIMIT = 4 * 1024 * 1024 * 1024
 
 def get_image_size(image_name):

--- a/.github/scripts/docker_update.py
+++ b/.github/scripts/docker_update.py
@@ -43,8 +43,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger("docker-update")
 
-# Size limit for Docker Scout scanning (4GB in bytes)
-DOCKER_SCOUT_SIZE_LIMIT = 4 * 1024 * 1024 * 1024
+# Size limit for Docker Scout scanning (3GB in bytes)
+DOCKER_SCOUT_SIZE_LIMIT = 3 * 1024 * 1024 * 1024
 
 def get_image_size(image_name):
     """

--- a/.github/scripts/docker_update.py
+++ b/.github/scripts/docker_update.py
@@ -44,7 +44,7 @@ logging.basicConfig(
 logger = logging.getLogger("docker-update")
 
 # Size limit for Docker Scout scanning (5GB in bytes)
-DOCKER_SCOUT_SIZE_LIMIT = 5 * 1024 * 1024 * 1024
+DOCKER_SCOUT_SIZE_LIMIT = 4 * 1024 * 1024 * 1024
 
 def get_image_size(image_name):
     """


### PR DESCRIPTION
## Description
- Unfortunately ran into another image-size-related issue with the `docker scout` command during the Build-and-Push GitHub Action (specifically with cnvkit).
- Going to reduce the size limit for that operation from 5GB to 3GB just to be safe.

## Related Issue
- Further addresses #214 

## Testing
- Running using a manual trigger of the GHA...