### PR TITLE
Removing non-root user from CNVkit Docker image

### DIFF
--- a/cnvkit/Dockerfile_0.9.10
+++ b/cnvkit/Dockerfile_0.9.10
@@ -44,9 +44,6 @@ RUN apt-get update && \
     r-base-dev="${RBASEDEV_VERSION}" \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN useradd --create-home --shell /bin/bash cnvkit
-
 # Set working directory
 WORKDIR /home/cnvkit
 
@@ -59,9 +56,6 @@ RUN pip install --no-cache-dir \
 # Install R packages required by CNVkit
 RUN R -e "install.packages(c('BiocManager', 'ggplot2', 'gridExtra', 'RColorBrewer'))" && \
     R -e "BiocManager::install(c('DNAcopy', 'PSCBS', 'GenomicRanges', 'IRanges'))"
-
-# Switch to non-root user
-USER cnvkit
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/cnvkit/Dockerfile_latest
+++ b/cnvkit/Dockerfile_latest
@@ -44,9 +44,6 @@ RUN apt-get update && \
     r-base-dev="${RBASEDEV_VERSION}" \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN useradd --create-home --shell /bin/bash cnvkit
-
 # Set working directory
 WORKDIR /home/cnvkit
 
@@ -59,9 +56,6 @@ RUN pip install --no-cache-dir \
 # Install R packages required by CNVkit
 RUN R -e "install.packages(c('BiocManager', 'ggplot2', 'gridExtra', 'RColorBrewer'))" && \
     R -e "BiocManager::install(c('DNAcopy', 'PSCBS', 'GenomicRanges', 'IRanges'))"
-
-# Switch to non-root user
-USER cnvkit
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/cnvkit/README.md
+++ b/cnvkit/README.md
@@ -75,7 +75,6 @@ apptainer run --bind /path/to/data:/data docker://getwilds/cnvkit:latest cnvkit.
 
 The CNVkit Docker images include:
 
-- Non-root user execution for enhanced security
 - Installation through pip to ensure properly built packages
 - Pinned versions for reproducibility (including Cython and NumPy compatibility versions)
 - Minimal dependencies to reduce attack surface
@@ -98,11 +97,10 @@ The Dockerfile follows these main steps:
 2. Adds metadata labels for documentation and attribution
 3. Sets environment variables for Python optimization
 4. Installs system dependencies (R, build tools, BLAS/LAPACK libraries) with pinned versions
-5. Creates a non-root user for security
+5. Sets working directory
 6. Installs CNVkit 0.9.10 with compatible dependency versions (Cython <3.0, NumPy <1.25)
 7. Installs essential R packages for CNVkit functionality
 8. Configures health checks and default command
-9. Switches to non-root user execution
 
 ## Source Repository
 


### PR DESCRIPTION
## Description
- During testing of ww-cnvkit, we ran into issues with the soft linkages used in the `create_reference` task.
- Turns out that the non-root user we were using in the `cnvkit` image was causing permissions issue.
- Removing the non-root user, but leaving the rest of the image the same.

## Testing
- Built locally, worked great.
- Minimal functionality change.