### PR TITLE
Adding Makefile for easier local linting/testing

### DIFF
--- a/.github/scripts/docker_update.py
+++ b/.github/scripts/docker_update.py
@@ -50,20 +50,29 @@ logger = logging.getLogger("docker-update")
 # Size limit for Docker Scout scanning (3GB in bytes)
 DOCKER_SCOUT_SIZE_LIMIT = 3 * 1024 * 1024 * 1024
 
+
+def load_amd64_only_tools():
+    """
+    Load the list of AMD64-only tools from amd64_only_tools.txt.
+
+    Returns:
+        set: Set of tool names that should only be built for AMD64
+    """
+    amd64_only_file = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "amd64_only_tools.txt"
+    )
+    try:
+        with open(amd64_only_file, "r") as f:
+            return {line.strip() for line in f if line.strip()}
+    except FileNotFoundError:
+        logger.warning(f"amd64_only_tools.txt not found at {amd64_only_file}, using empty set")
+        return set()
+
+
 # Tools that should only be built for AMD64 (not ARM64)
-# Add tool names here if they have architecture-specific dependencies
-AMD64_ONLY_TOOLS = {
-    "bwa",
-    "deseq2",
-    "hisat2",
-    "manta",
-    "python-dl",
-    "rtorch",
-    "scvi-tools",
-    "smoove",
-    "sra-tools",
-    "strelka",
-}
+# Loaded from amd64_only_tools.txt
+AMD64_ONLY_TOOLS = load_amd64_only_tools()
 
 
 def get_image_size(image_name):

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ build_arm64: check_for_docker check_image ## Build Docker image(s) for ARM64 arc
 	@set -e; for dir in $(IMAGE)/; do \
 		if [ -d "$$dir" ]; then \
 			image_name=$$(basename "$$dir"); \
+			if grep -q "^$$image_name$$" amd64_only_tools.txt 2>/dev/null; then \
+				echo "Skipping $$image_name (AMD64 only)"; \
+				continue; \
+			fi; \
 			for dockerfile in $$dir/Dockerfile*; do \
 				if [ -f "$$dockerfile" ]; then \
 					version=$$(echo "$$dockerfile" | sed 's/.*Dockerfile_//'); \

--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -1,0 +1,10 @@
+bwa
+deseq2
+hisat2
+manta
+python-dl
+rtorch
+scvi-tools
+smoove
+sra-tools
+strelka


### PR DESCRIPTION
## Summary

This PR adds a Makefile to simplify local development and testing of WILDS Docker images, making it easier for contributors to validate their changes before pushing to CI/CD.

## What's New

### Makefile Targets

**Linting:**
- `make lint` - Run hadolint on all Dockerfiles (or specific image with `IMAGE=toolname`)
- Automatically checks for hadolint installation and provides helpful error messages

**Building:**
- `make build_amd64` - Build Docker images for AMD64 architecture
- `make build_arm64` - Build Docker images for ARM64 architecture  
- `make build` - Build for both architectures
- Supports building all images or a specific image with `IMAGE=toolname`
- Skips images only intended for AMD64 architecture (defined in amd64_only_tools.txt)
- Automatic cleanup with `PRUNE=1` to manage disk space

**Testing:**
- `make test` - Complete test suite: lint + build both architectures
- Validates changes locally before committing

**Developer Experience:**
- `make help` - Shows all available targets with descriptions
- Built-in checks for required tools (hadolint, docker) with installation links
- `make clean` - Cleans up all built images to save space when done

### Key Features

- **Smart defaults**: Builds all images by default, or target specific ones with `IMAGE=samtools`
- **Automatic pruning**: When building all images, automatically cleans up Docker cache between builds
- **Version detection**: Parses `Dockerfile_X.Y.Z` filenames to create correctly tagged images
- **Error handling**: `set -e` in build loop ensures failures stop execution immediately

## Why This Matters

Contributors can now:
- **Validate locally** before pushing (same linting rules as CI)
- **Test multi-arch builds** without GitHub Actions
- **Iterate faster** with quick feedback loops
- **Avoid CI failures** by catching issues early

## Example Usage

```bash
# Lint all Dockerfiles
make lint

# Lint specific tool
make lint IMAGE=samtools

# Build specific tool for testing
make build IMAGE=samtools

# Run full test suite on all images
make test

# Clean up all images
make clean IMAGE=samtools
```

## Related Issues
- Fixes #281

## Testing
- Ran all commands locally, seems to work as expected.