### PR TITLE
Removing bedops from the AMD64 Only list

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -1,4 +1,3 @@
-bedops
 bwa
 deseq2
 hisat2


### PR DESCRIPTION
## Description
- Removing the bedops image from the AMD64-Only list, stupidly forgot to commit that in the last PR... 🤦 