### PR TITLE
Adding initial version of Salmon Docker image

### DIFF
--- a/salmon/Dockerfile_1.10.3
+++ b/salmon/Dockerfile_1.10.3
@@ -1,0 +1,64 @@
+# Using the Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="salmon"
+LABEL org.opencontainers.image.description="Docker image for the use of Salmon in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="1.10.3"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing prerequisites for building Salmon
+RUN apt-get update \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && CURL_VERSION=$(apt-cache policy curl | grep Candidate | awk '{print $2}') \
+  && UNZIP_VERSION=$(apt-cache policy unzip | grep Candidate | awk '{print $2}') \
+  && CMAKE_VERSION=$(apt-cache policy cmake | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+  && LIBBOOST_VERSION=$(apt-cache policy libboost-all-dev | grep Candidate | awk '{print $2}') \
+  && LIBTBB_VERSION=$(apt-cache policy libtbb-dev | grep Candidate | awk '{print $2}') \
+  && ZLIB1G_VERSION=$(apt-cache policy zlib1g-dev | grep Candidate | awk '{print $2}') \
+  && LIBBZ2_VERSION=$(apt-cache policy libbz2-dev | grep Candidate | awk '{print $2}') \
+  && LIBLZMA_VERSION=$(apt-cache policy liblzma-dev | grep Candidate | awk '{print $2}') \
+  && LIBZSTD_VERSION=$(apt-cache policy libzstd-dev | grep Candidate | awk '{print $2}') \
+  && LIBCURL4_VERSION=$(apt-cache policy libcurl4-gnutls-dev | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  wget="${WGET_VERSION}" \
+  curl="${CURL_VERSION}" \
+  unzip="${UNZIP_VERSION}" \
+  cmake="${CMAKE_VERSION}" \
+  git="${GIT_VERSION}" \
+  libboost-all-dev="${LIBBOOST_VERSION}" \
+  libtbb-dev="${LIBTBB_VERSION}" \
+  zlib1g-dev="${ZLIB1G_VERSION}" \
+  libbz2-dev="${LIBBZ2_VERSION}" \
+  liblzma-dev="${LIBLZMA_VERSION}" \
+  libzstd-dev="${LIBZSTD_VERSION}" \
+  libcurl4-gnutls-dev="${LIBCURL4_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pulling and extracting Salmon source code
+RUN wget -q --no-check-certificate https://github.com/COMBINE-lab/salmon/archive/refs/tags/v1.10.3.tar.gz \
+  && tar -xzf v1.10.3.tar.gz
+
+# Building and installing Salmon
+RUN mkdir /salmon-1.10.3/build
+WORKDIR /salmon-1.10.3/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. \
+  && make \
+  && make install
+
+# Return to root directory
+WORKDIR /
+
+# Cleanup and smoke test to verify salmon works on target architecture
+RUN rm -rf salmon-1.10.3 v1.10.3.tar.gz \
+  && salmon --version

--- a/salmon/Dockerfile_latest
+++ b/salmon/Dockerfile_latest
@@ -1,0 +1,64 @@
+# Using the Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="salmon"
+LABEL org.opencontainers.image.description="Docker image for the use of Salmon in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing prerequisites for building Salmon
+RUN apt-get update \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && CURL_VERSION=$(apt-cache policy curl | grep Candidate | awk '{print $2}') \
+  && UNZIP_VERSION=$(apt-cache policy unzip | grep Candidate | awk '{print $2}') \
+  && CMAKE_VERSION=$(apt-cache policy cmake | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+  && LIBBOOST_VERSION=$(apt-cache policy libboost-all-dev | grep Candidate | awk '{print $2}') \
+  && LIBTBB_VERSION=$(apt-cache policy libtbb-dev | grep Candidate | awk '{print $2}') \
+  && ZLIB1G_VERSION=$(apt-cache policy zlib1g-dev | grep Candidate | awk '{print $2}') \
+  && LIBBZ2_VERSION=$(apt-cache policy libbz2-dev | grep Candidate | awk '{print $2}') \
+  && LIBLZMA_VERSION=$(apt-cache policy liblzma-dev | grep Candidate | awk '{print $2}') \
+  && LIBZSTD_VERSION=$(apt-cache policy libzstd-dev | grep Candidate | awk '{print $2}') \
+  && LIBCURL4_VERSION=$(apt-cache policy libcurl4-gnutls-dev | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  wget="${WGET_VERSION}" \
+  curl="${CURL_VERSION}" \
+  unzip="${UNZIP_VERSION}" \
+  cmake="${CMAKE_VERSION}" \
+  git="${GIT_VERSION}" \
+  libboost-all-dev="${LIBBOOST_VERSION}" \
+  libtbb-dev="${LIBTBB_VERSION}" \
+  zlib1g-dev="${ZLIB1G_VERSION}" \
+  libbz2-dev="${LIBBZ2_VERSION}" \
+  liblzma-dev="${LIBLZMA_VERSION}" \
+  libzstd-dev="${LIBZSTD_VERSION}" \
+  libcurl4-gnutls-dev="${LIBCURL4_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Pulling and extracting Salmon source code
+RUN wget -q --no-check-certificate https://github.com/COMBINE-lab/salmon/archive/refs/tags/v1.10.3.tar.gz \
+  && tar -xzf v1.10.3.tar.gz
+
+# Building and installing Salmon
+RUN mkdir /salmon-1.10.3/build
+WORKDIR /salmon-1.10.3/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. \
+  && make \
+  && make install
+
+# Return to root directory
+WORKDIR /
+
+# Cleanup and smoke test to verify salmon works on target architecture
+RUN rm -rf salmon-1.10.3 v1.10.3.tar.gz \
+  && salmon --version

--- a/salmon/README.md
+++ b/salmon/README.md
@@ -1,0 +1,130 @@
+# Salmon
+
+This directory contains Docker images for Salmon, a "wicked-fast program to produce highly-accurate, transcript-level quantification estimates from RNA-seq data" using selective alignment.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/salmon/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/salmon/CVEs_latest.md) )
+- `1.10.3` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/salmon/Dockerfile_1.10.3) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/salmon/CVEs_1.10.3.md) )
+
+## Image Details
+
+These Docker images are built from Ubuntu 24.04 and include:
+
+- Salmon v1.10.3: Fast and bias-aware transcript quantification tool for RNA-seq data
+- System dependencies: Boost, TBB (Threading Building Blocks), zlib, bz2, lzma, zstd, curl
+
+The images are designed to be minimal and focused on Salmon with its essential dependencies. Salmon is built from source to ensure compatibility across both AMD64 and ARM64 architectures.
+
+## Citation
+
+If you use Salmon in your research, please cite the original authors:
+
+```
+Patro, R., Duggal, G., Love, M. I., Irizarry, R. A., & Kingsford, C. (2017).
+Salmon provides fast and bias-aware quantification of transcript expression.
+Nature Methods, 14(4), 417-419.
+https://doi.org/10.1038/nmeth.4197
+```
+
+**Tool homepage:** https://github.com/COMBINE-lab/salmon
+
+**Documentation:** https://salmon.readthedocs.io/
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/salmon:latest
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/salmon:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/salmon:latest
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/salmon:latest
+```
+
+### Example Commands
+
+```bash
+# Example 1: Index a transcriptome (FASTA file)
+docker run --rm -v /path/to/data:/data getwilds/salmon:latest \
+  salmon index -t /data/transcripts.fa -i /data/salmon_index
+
+# Example 2: Quantify paired-end reads
+docker run --rm -v /path/to/data:/data getwilds/salmon:latest \
+  salmon quant -i /data/salmon_index \
+  -l A \
+  -1 /data/reads_1.fastq.gz \
+  -2 /data/reads_2.fastq.gz \
+  -o /data/salmon_output
+
+# Example 3: Quantify single-end reads with validation
+docker run --rm -v /path/to/data:/data getwilds/salmon:latest \
+  salmon quant -i /data/salmon_index \
+  -l A \
+  -r /data/reads.fastq.gz \
+  --validateMappings \
+  -o /data/salmon_output
+
+# Example 4: Using Apptainer with paired-end reads
+apptainer run --bind /path/to/data:/data docker://getwilds/salmon:latest \
+  salmon quant -i /data/salmon_index \
+  -l A \
+  -1 /data/reads_1.fastq.gz \
+  -2 /data/reads_2.fastq.gz \
+  -o /data/salmon_output
+
+# Example 5: Using a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data salmon_latest.sif \
+  salmon quant -i /data/salmon_index \
+  -l A \
+  -1 /data/reads_1.fastq.gz \
+  -2 /data/reads_2.fastq.gz \
+  -o /data/salmon_output
+```
+
+## Important Notes
+
+### Library Type Detection
+
+Salmon can automatically detect the library type using `-l A` (automatic detection), which is convenient for most use cases. However, you can also specify the library type explicitly (e.g., `-l ISF` for paired-end reads with inward-facing reads from the forward strand). See the [Salmon documentation](https://salmon.readthedocs.io/en/latest/library_type.html) for more details on library types.
+
+### Selective Alignment
+
+Starting with version 1.0.0, Salmon uses selective alignment by default, which provides improved accuracy. This is the mapping strategy used in these images.
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Ubuntu 24.04 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs system dependencies with pinned versions (build tools, Boost, TBB, compression libraries)
+4. Downloads Salmon v1.10.3 source code from GitHub
+5. Builds Salmon from source using CMake
+6. Performs cleanup to minimize image size
+7. Runs a smoke test to verify the installation
+
+Building from source ensures compatibility across both AMD64 and ARM64 architectures.
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/salmon), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.


### PR DESCRIPTION
## Summary

Adds Docker images for Salmon v1.10.3, a fast and bias-aware transcript quantification tool for RNA-seq data.

## What's included

- **Dockerfile_latest** and **Dockerfile_1.10.3**: Multi-architecture Dockerfiles that build Salmon from source
- **README.md**: Comprehensive documentation with usage examples, citation information, and library type detection notes
- Built on Ubuntu 24.04 with all necessary dependencies (Boost, TBB, compression libraries)
- Supports both AMD64 and ARM64 architectures

## Testing

- AMD64 build completes successfully
- ARM64 build completes successfully
- Smoke test passes (`salmon --version`)
- Will test with ww-salmon in the WILDS WDL Library once merged