### PR TITLE
Adding initial version of gdc-client WILDS Docker image

### DIFF
--- a/gdc-client/Dockerfile_2.3.0
+++ b/gdc-client/Dockerfile_2.3.0
@@ -1,0 +1,37 @@
+# Using Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gdc-client"
+LABEL org.opencontainers.image.description="Docker image for TCGA GDC Data Transfer Tool in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="2.3.0"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set environment for non-interactive installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update \
+  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
+  && PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+     python3="${PYTHON3_VERSION}" \
+     python3-pip="${PIP_VERSION}" \
+     git="${GIT_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install gdc-client from GitHub and run smoke test
+RUN pip3 install --no-cache-dir --break-system-packages \
+  git+https://github.com/NCI-GDC/gdc-client.git@2.3 \
+  && gdc-client --version
+
+# Set working directory
+WORKDIR /data

--- a/gdc-client/Dockerfile_latest
+++ b/gdc-client/Dockerfile_latest
@@ -1,0 +1,37 @@
+# Using Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gdc-client"
+LABEL org.opencontainers.image.description="Docker image for TCGA GDC Data Transfer Tool in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set environment for non-interactive installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update \
+  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
+  && PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+     python3="${PYTHON3_VERSION}" \
+     python3-pip="${PIP_VERSION}" \
+     git="${GIT_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install gdc-client from GitHub and run smoke test
+RUN pip3 install --no-cache-dir --break-system-packages \
+  git+https://github.com/NCI-GDC/gdc-client.git@2.3 \
+  && gdc-client --version
+
+# Set working directory
+WORKDIR /data

--- a/gdc-client/README.md
+++ b/gdc-client/README.md
@@ -1,0 +1,142 @@
+# GDC Data Transfer Tool (gdc-client)
+
+This directory contains Docker images for the GDC Data Transfer Tool (gdc-client), the official command-line tool for downloading and uploading data from the NCI Genomic Data Commons (GDC).
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/gdc-client/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/gdc-client/CVEs_latest.md) )
+- `2.3.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/gdc-client/Dockerfile_2.3.0) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/gdc-client/CVEs_2.3.0.md) )
+
+## Image Details
+
+These Docker images are built from Ubuntu 24.04 and include:
+
+- GDC Data Transfer Tool v2.3: Command-line tool for data transfer to/from the GDC
+- Python 3: Required runtime for gdc-client
+- Git: Required for installation from GitHub source
+
+The images are designed to provide a minimal, reproducible environment for accessing TCGA and other cancer genomics datasets from the Genomic Data Commons. The gdc-client is installed directly from the official NCI-GDC GitHub repository.
+
+## Citation
+
+If you use the GDC Data Transfer Tool in your research, please cite the Genomic Data Commons:
+
+```
+National Cancer Institute GDC Data Portal. https://gdc.cancer.gov
+```
+
+**Tool homepage:** https://gdc.cancer.gov/access-data/gdc-data-transfer-tool
+
+**Documentation:** https://docs.gdc.cancer.gov/Data_Transfer_Tool/Users_Guide/Getting_Started/
+
+**GitHub repository:** https://github.com/NCI-GDC/gdc-client
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/gdc-client:latest
+
+# Or pull a specific version
+docker pull getwilds/gdc-client:2.3.0
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/gdc-client:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/gdc-client:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/gdc-client:2.3.0
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/gdc-client:latest
+```
+
+### Example Commands
+
+```bash
+# Download a single file using its UUID
+docker run --rm -v /path/to/data:/data getwilds/gdc-client:latest \
+  gdc-client download 22a29915-6712-4f7a-8dba-985ae9a1f005
+
+# Download multiple files from a manifest
+docker run --rm -v /path/to/data:/data getwilds/gdc-client:latest \
+  gdc-client download -m /data/gdc_manifest.txt
+
+# Download with multiple threads for better performance
+docker run --rm -v /path/to/data:/data getwilds/gdc-client:latest \
+  gdc-client download -m /data/gdc_manifest.txt -n 8
+
+# Download files using a token for controlled-access data
+docker run --rm -v /path/to/data:/data -v /path/to/token:/token getwilds/gdc-client:latest \
+  gdc-client download -m /data/gdc_manifest.txt -t /token/gdc-user-token.txt
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/gdc-client:latest \
+  gdc-client download -m /data/gdc_manifest.txt -n 8
+
+# ... or a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data gdc-client_latest.sif \
+  gdc-client download 22a29915-6712-4f7a-8dba-985ae9a1f005
+```
+
+## Important Notes
+
+### Data Download Location
+
+By default, gdc-client downloads files to the current working directory. The Docker image sets `/data` as the working directory, so files will be downloaded there when you mount your local directory to `/data`.
+
+### Authentication for Controlled-Access Data
+
+To download controlled-access data, you need a GDC authentication token:
+
+1. Log in to the [GDC Data Portal](https://portal.gdc.cancer.gov/)
+2. Download your authentication token
+3. Mount the token file and use the `-t` flag:
+
+```bash
+docker run --rm -v /path/to/data:/data -v /path/to/token.txt:/token.txt \
+  getwilds/gdc-client:latest \
+  gdc-client download -m /data/manifest.txt -t /token.txt
+```
+
+### Generating Manifests
+
+Manifests can be generated from the GDC Data Portal by:
+
+1. Selecting files in the repository or cart
+2. Clicking the "Download" button
+3. Selecting "Manifest" option
+
+The manifest is a tab-delimited file containing file UUIDs and metadata.
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Ubuntu 24.04 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs system dependencies (Python 3, pip, git) with pinned versions for security
+4. Installs gdc-client v2.3 directly from the official NCI-GDC GitHub repository using pip
+5. Performs cleanup to minimize image size
+6. Runs a smoke test to verify the installation
+7. Sets `/data` as the working directory
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/gdc-client), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.


### PR DESCRIPTION
## Summary

Adds Docker images for the GDC Data Transfer Tool (gdc-client) v2.3, the official command-line tool for downloading and uploading data from the NCI Genomic Data Commons.

## What's included

- **Base image**: Ubuntu 24.04
- **Tool version**: gdc-client v2.3 (installed from official NCI-GDC GitHub repository)
- **Dependencies**: Python 3, pip, git (all with pinned versions)

## Installation method

The tool is installed via pip directly from the official GitHub repository (`git+https://github.com/NCI-GDC/gdc-client.git@2.3`) rather than using pre-compiled binaries, ensuring a reproducible build process.

## Use cases

This image enables users to:
- Download TCGA and other cancer genomics datasets from the GDC
- Access both open-access and controlled-access data (with authentication tokens)
- Perform multi-threaded downloads for improved performance
- Work with GDC manifest files for batch downloads

## Files added

- `gdc-client/Dockerfile_latest`
- `gdc-client/Dockerfile_2.3.0`
- `gdc-client/README.md`

## Testing
- Built locally, works as expected.