### PR TITLE
Adding bash to the ena-tools Docker image

### DIFF
--- a/ena-tools/Dockerfile_2.1.1
+++ b/ena-tools/Dockerfile_2.1.1
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 ENV ENA_DOWNLOADER_VERSION=2.1.1
 
 # Download and install ENA FTP Downloader
-RUN apk add --no-cache wget=1.25.0-r1 unzip=6.0-r15 \
+RUN apk add --no-cache wget=1.25.0-r1 unzip=6.0-r15 bash=5.2.37-r0 \
   && wget -q https://ftp.ebi.ac.uk/pub/databases/ena/tools/ena-file-downloader.zip \
   && unzip ena-file-downloader.zip \
   && mv ena-file-downloader.jar /usr/local/bin/ \

--- a/ena-tools/Dockerfile_latest
+++ b/ena-tools/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 ENV ENA_DOWNLOADER_VERSION=2.1.1
 
 # Download and install ENA FTP Downloader
-RUN apk add --no-cache wget=1.25.0-r1 unzip=6.0-r15 \
+RUN apk add --no-cache wget=1.25.0-r1 unzip=6.0-r15 bash=5.2.37-r0 \
   && wget -q https://ftp.ebi.ac.uk/pub/databases/ena/tools/ena-file-downloader.zip \
   && unzip ena-file-downloader.zip \
   && mv ena-file-downloader.jar /usr/local/bin/ \

--- a/ena-tools/README.md
+++ b/ena-tools/README.md
@@ -182,11 +182,11 @@ The Dockerfile follows these main steps:
 
 1. Uses Eclipse Temurin JRE 21 Alpine as the base image for minimal size
 2. Adds metadata labels for documentation and attribution
-3. Installs wget and unzip with pinned versions
+3. Installs wget, unzip, and bash with pinned versions
 4. Downloads the ENA FTP Downloader ZIP from the official ENA FTP site
 5. Extracts and installs the JAR file to `/usr/local/bin`
 6. Creates a convenient wrapper script (`ena-downloader`) for easier execution
-7. Performs cleanup to minimize image size
+7. Performs cleanup to minimize image size (removes wget and unzip, keeps bash for WDL compatibility)
 8. Verifies the tool is functional via help command
 
 ## Security Scanning and CVEs


### PR DESCRIPTION
## Summary
- Add bash to ena-tools Docker images for WDL compatibility
- Bash is required by WDL workflow engines when executing commands in containers
- Updated README to document bash inclusion

## Changes Made
- Added `bash=5.2.37-r0` to package installations in both Dockerfiles
- Bash is kept in final image while wget/unzip are removed after use
- Updated Dockerfile Structure section in README to reflect bash installation

## Testing
- Docker image builds successfully
- `bash --version` executes without error
- Tool works correctly when invoked via bash (WDL execution pattern)
- Successfully tested download workflow with bash wrapper

## Related Issue
- Further addresses #305 