### PR TITLE
Add Cell Ranger v10.0.0 image

### DIFF
--- a/cellranger/Dockerfile_10.0.0
+++ b/cellranger/Dockerfile_10.0.0
@@ -41,11 +41,10 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Download and install Cell Ranger pre-built binary
-# Note: Because the key for this link expires, these containers are
-# excluded from the automated build-and-push GitHub Action.
-# To make changes, provide an updated link and reupload manually.
+# Note: The download URL contains a signed key that expires.
+# A new download URL should be obtained from 10x Genomics each time this Dockerfile is updated.
 RUN wget -q --no-check-certificate -O cellranger-10.0.0.tar.gz \
-  "https://cf.10xgenomics.com/releases/cell-exp/cellranger-10.0.0.tar.gz?Expires=1766145670&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=glFsXIGKiPhvX17igjC5Tc-hK-tz8Xv7WWDOtrPoPnCaRkO2LyWKDk1daxIYHnJHTgfKgX6-Em5AYsFBF-MdYLrMwUS91AwWtJowJuqw9EWaDi5CtniTSyILyq~i2urxkVJ9-~mbUX0KdwP4y447SX87BPV0ZNzrs1lC968dkhsL-Rw8pRjawgfjK9Pb~~S0l1O4esXrRiY8rHAJr5yXqp2rwmakIUVYXFRdCwJUuhMMkLK0rxFJhqNICSTb6fpOGNBwQOn8F1TUaeVOoXdpQ0QvhO5~6Cn2gL8St2JAZo9pGhQalLknuS0ymhUTZEWHcacsPea72WA9jwSDEJc8Tw__" \
+  "https://cf.10xgenomics.com/releases/cell-exp/cellranger-10.0.0.tar.gz?Expires=1766424907&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=Se7y~SfN80~5Q61MkUOLIgsO40FlwMj6BuJjAmP6S74H7ZI6PSI8CCZgOHMoz3BUYZKhKwI~oC5sUqUqMbzw3wbmJcmrhPneNagGvnDwRmULTA6Smyn4K7A-k0t7qjVW5W8aiERueW5057JJk4LKPZJHKoV7tqMVA5beAU4Ari2Deu5K5hHKfNK0OWIYl9mxlAP8mg2Go6KzhOVFKAQy-VzoqpGFSOW3jSnHAMrOhHtpX4jdhshm-Kca2NeSAZome4j6uPfUyKYdQRWTwOI1EgXcyRFRBHEQe6TVsOt4IqxtCYKEgjLm3SDt5f5Nzds5plRJ~V2jpcG-ew5ABnUXNg__" \
   && tar -xzf cellranger-10.0.0.tar.gz \
   && rm -rf cellranger-10.0.0.tar.gz
 

--- a/cellranger/Dockerfile_6.0.2
+++ b/cellranger/Dockerfile_6.0.2
@@ -12,23 +12,47 @@ LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Installing prerequisites
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential=12.10ubuntu1 wget=1.21.4-1ubuntu4 \
-  zlib1g-dev=1:1.3.dfsg-3.1ubuntu2 autoconf=2.71-3 automake=1:1.16.5-1.3ubuntu1 \
-  libncurses-dev=6.4+20240113-1ubuntu2 libbz2-dev=1.0.8-5.1 liblzma-dev=5.6.1+really5.4.5-1 \
-  libssl-dev=3.0.13-0ubuntu3.1 libcurl4-gnutls-dev=8.5.0-2ubuntu10.1 \
+  && BUILD_ESSENTIAL_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && ZLIB1G_DEV_VERSION=$(apt-cache policy zlib1g-dev | grep Candidate | awk '{print $2}') \
+  && AUTOCONF_VERSION=$(apt-cache policy autoconf | grep Candidate | awk '{print $2}') \
+  && AUTOMAKE_VERSION=$(apt-cache policy automake | grep Candidate | awk '{print $2}') \
+  && LIBNCURSES_DEV_VERSION=$(apt-cache policy libncurses-dev | grep Candidate | awk '{print $2}') \
+  && LIBBZ2_DEV_VERSION=$(apt-cache policy libbz2-dev | grep Candidate | awk '{print $2}') \
+  && LIBLZMA_DEV_VERSION=$(apt-cache policy liblzma-dev | grep Candidate | awk '{print $2}') \
+  && LIBSSL_DEV_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
+  && LIBCURL4_GNUTLS_DEV_VERSION=$(apt-cache policy libcurl4-gnutls-dev | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BUILD_ESSENTIAL_VERSION}" \
+  wget="${WGET_VERSION}" \
+  zlib1g-dev="${ZLIB1G_DEV_VERSION}" \
+  autoconf="${AUTOCONF_VERSION}" \
+  automake="${AUTOMAKE_VERSION}" \
+  libncurses-dev="${LIBNCURSES_DEV_VERSION}" \
+  libbz2-dev="${LIBBZ2_DEV_VERSION}" \
+  liblzma-dev="${LIBLZMA_DEV_VERSION}" \
+  libssl-dev="${LIBSSL_DEV_VERSION}" \
+  libcurl4-gnutls-dev="${LIBCURL4_GNUTLS_DEV_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-# Pulling and extracting Cell Ranger source code
+# Download and install Cell Ranger pre-built binary
+# Note: The download URL contains a signed key that expires.
+# A new download URL should be obtained from 10x Genomics each time this Dockerfile is updated.
 RUN wget -q --no-check-certificate -O cellranger-6.0.2.tar.gz \
-  "https://cf.10xgenomics.com/releases/cell-exp/cellranger-6.0.2.tar.gz?Expires=1718037805&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=kkUm5ag6YEEohqvg6KHzR4RN4wWL3haRIVoPYmF0ZGG32mSScnfvwog-W2UH7i5gRW1joN8ZtYBTDvkNcY--8ULKaGE0CM6uMrF5bURZiqUVRFXEjf2e7OwFwR6RqXchC5GzNCrK4wPnVwoe9m2Qavem5twz2-U7jf8INPZp0OcgwAgwrzsEdkcdhbxkGaRCRoB629cCVmfJnbOaznErUbHzNk4gp2P2pbWlIPDgnrOQDg2jzC7FJPn9tTOH3QuIVYvBeBF~Vj2xCeWFYX1ajmvC~tLywAecUQ6wT0MpNyNVvkygynSJnXENby8DGZXfLLP0JclcoQqe8oKG1VmJhA__" && tar -zxvf cellranger-6.0.2.tar.gz
-# Note: Because the key for this link expires, these containers are 
-# excluded from the automated build-and-push GitHub Action. 
-# To make changes, provide an updated link and reupload manually.
+  "https://cf.10xgenomics.com/releases/cell-exp/cellranger-6.0.2.tar.gz?Expires=1766424907&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=jLI49CMfXFI-E7Sd0sNNPNemtXGQuS4HqPt4rZOR6Hv9r0GSKgdILNv6zJWbtiaBuwZQ~X4AnGHccHCJeIRIE5WEhASaExvaKy6lD550oc9nSHBemUZo4SXEbaG~F25-G5ZKv~jY5y2yj0ljXN5iy42zRvLFmnZHHQeaBEHai-mEIBtzcqKomOIuT7QaHsmbWJQKKzRd~JvkyAhYaI2gQOfo-EAsAPTMRE-enDNoSO4ZPmDn~erbEEHHie60Yxg47D1nXu6wzoWuAKcARXOXACdaRRHx5KsMp05l2pGzmuYt6B6~iOVT~y1KHngXTmlhqM0ZmdLkFc0KbK65upcVFw__" \
+  && tar -zxvf cellranger-6.0.2.tar.gz \
+  && rm -rf cellranger-6.0.2.tar.gz
 
 # Installing Cell Ranger
 ENV PATH="${PATH}:/cellranger-6.0.2"
 
-# Cleanup
-RUN rm -rf cellranger-6.0.2.tar.gz 
+# Set working directory
+WORKDIR /data
+
+# Smoke test (NOTE: Cell Ranger only works on x86_64 Linux)
+RUN cellranger --version

--- a/cellranger/Dockerfile_latest
+++ b/cellranger/Dockerfile_latest
@@ -41,11 +41,10 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Download and install Cell Ranger pre-built binary
-# Note: Because the key for this link expires, these containers are
-# excluded from the automated build-and-push GitHub Action.
-# To make changes, provide an updated link and reupload manually.
+# Note: The download URL contains a signed key that expires.
+# A new download URL should be obtained from 10x Genomics each time this Dockerfile is updated.
 RUN wget -q --no-check-certificate -O cellranger-10.0.0.tar.gz \
-  "https://cf.10xgenomics.com/releases/cell-exp/cellranger-10.0.0.tar.gz?Expires=1766145670&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=glFsXIGKiPhvX17igjC5Tc-hK-tz8Xv7WWDOtrPoPnCaRkO2LyWKDk1daxIYHnJHTgfKgX6-Em5AYsFBF-MdYLrMwUS91AwWtJowJuqw9EWaDi5CtniTSyILyq~i2urxkVJ9-~mbUX0KdwP4y447SX87BPV0ZNzrs1lC968dkhsL-Rw8pRjawgfjK9Pb~~S0l1O4esXrRiY8rHAJr5yXqp2rwmakIUVYXFRdCwJUuhMMkLK0rxFJhqNICSTb6fpOGNBwQOn8F1TUaeVOoXdpQ0QvhO5~6Cn2gL8St2JAZo9pGhQalLknuS0ymhUTZEWHcacsPea72WA9jwSDEJc8Tw__" \
+  "https://cf.10xgenomics.com/releases/cell-exp/cellranger-10.0.0.tar.gz?Expires=1766424907&Key-Pair-Id=APKAI7S6A5RYOXBWRPDA&Signature=Se7y~SfN80~5Q61MkUOLIgsO40FlwMj6BuJjAmP6S74H7ZI6PSI8CCZgOHMoz3BUYZKhKwI~oC5sUqUqMbzw3wbmJcmrhPneNagGvnDwRmULTA6Smyn4K7A-k0t7qjVW5W8aiERueW5057JJk4LKPZJHKoV7tqMVA5beAU4Ari2Deu5K5hHKfNK0OWIYl9mxlAP8mg2Go6KzhOVFKAQy-VzoqpGFSOW3jSnHAMrOhHtpX4jdhshm-Kca2NeSAZome4j6uPfUyKYdQRWTwOI1EgXcyRFRBHEQe6TVsOt4IqxtCYKEgjLm3SDt5f5Nzds5plRJ~V2jpcG-ew5ABnUXNg__" \
   && tar -xzf cellranger-10.0.0.tar.gz \
   && rm -rf cellranger-10.0.0.tar.gz
 

--- a/cellranger/README.md
+++ b/cellranger/README.md
@@ -4,20 +4,25 @@ This directory contains Docker images for Cell Ranger, 10x Genomics' analysis pi
 
 ## Available Versions
 
-- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/CVEs_latest.md) )
+- `latest` (currently v10.0.0) ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/CVEs_latest.md) )
+- `10.0.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/Dockerfile_10.0.0) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/CVEs_10.0.0.md) )
 - `6.0.2` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/Dockerfile_6.0.2) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellranger/CVEs_6.0.2.md) )
 
 ## Image Details
 
 These Docker images are built from Ubuntu Noble and include:
 
-- Cell Ranger v6.0.2: A set of analysis pipelines that process Chromium single-cell RNA-seq output to align reads, generate feature-barcode matrices, perform clustering and other secondary analysis
+- Cell Ranger: A set of analysis pipelines that process Chromium single-cell RNA-seq output to align reads, generate feature-barcode matrices, perform clustering and other secondary analysis
 
 The images are designed to be minimal and focused on Cell Ranger with its dependencies.
 
+## Platform Availability
+
+**AMD64 only**: Cell Ranger only supports x86_64 (AMD64) Linux systems. These images will not run natively on ARM-based systems (e.g., Apple Silicon Macs). Docker Desktop on Apple Silicon can run these images through emulation, though with reduced performance.
+
 ## Important Note
 
-**Special Handling Required**: Due to the download link expiration for Cell Ranger, these containers are excluded from the automated build-and-push GitHub Action. To make changes, provide an updated link and reupload manually.
+**Special Handling Required**: The Cell Ranger download URL contains a signed key that expires. A new download URL should be obtained from 10x Genomics each time the Dockerfiles are updated.
 
 ## Usage
 
@@ -26,7 +31,7 @@ The images are designed to be minimal and focused on Cell Ranger with its depend
 ```bash
 docker pull getwilds/cellranger:latest
 # or
-docker pull getwilds/cellranger:6.0.2
+docker pull getwilds/cellranger:10.0.0
 
 # Alternatively, pull from GitHub Container Registry
 docker pull ghcr.io/getwilds/cellranger:latest
@@ -37,7 +42,7 @@ docker pull ghcr.io/getwilds/cellranger:latest
 ```bash
 apptainer pull docker://getwilds/cellranger:latest
 # or
-apptainer pull docker://getwilds/cellranger:6.0.2
+apptainer pull docker://getwilds/cellranger:10.0.0
 
 # Alternatively, pull from GitHub Container Registry
 apptainer pull docker://ghcr.io/getwilds/cellranger:latest
@@ -74,10 +79,11 @@ The Dockerfile follows these main steps:
 
 1. Uses Ubuntu Noble as the base image
 2. Adds metadata labels for documentation and attribution
-3. Installs prerequisites with pinned versions
-4. Downloads and extracts Cell Ranger source code using a temporary download link
-5. Adds Cell Ranger to the PATH
-6. Performs cleanup to minimize image size
+3. Sets shell options for better error handling in pipelines
+4. Installs prerequisites with pinned versions
+5. Downloads and extracts Cell Ranger pre-built binary using a temporary download link
+6. Adds Cell Ranger to the PATH and sets working directory
+7. Runs a smoke test to verify the installation
 
 ## Security Scanning and CVEs
 


### PR DESCRIPTION
## Description
This adds a Dockerfile for the latest version of Cell Ranger (`10.0.0`) and makes that file `_latest`

## Related Issue
Fixes #313 

## Testing
Smoke test is included in the Dockerfile, and I also ran it interactively to check.