### PR TITLE
Adding scikit-learn to jcast Dockerfiles

### DIFF
--- a/jcast/Dockerfile_0.3.5
+++ b/jcast/Dockerfile_0.3.5
@@ -23,6 +23,6 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   gcc="${GCC_VERSION}" \
   g++="${GPP_VERSION}" \
-  && pip install --no-cache-dir jcast==0.3.5 \
+  && pip install --no-cache-dir scikit-learn==1.6.1 jcast==0.3.5 \
   && apt-get purge -y --auto-remove gcc g++ \
   && rm -rf /var/lib/apt/lists/*

--- a/jcast/Dockerfile_latest
+++ b/jcast/Dockerfile_latest
@@ -23,6 +23,6 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   gcc="${GCC_VERSION}" \
   g++="${GPP_VERSION}" \
-  && pip install --no-cache-dir jcast==0.3.5 \
+  && pip install --no-cache-dir scikit-learn==1.6.1 jcast==0.3.5 \
   && apt-get purge -y --auto-remove gcc g++ \
   && rm -rf /var/lib/apt/lists/*

--- a/jcast/README.md
+++ b/jcast/README.md
@@ -12,6 +12,7 @@ This directory contains Docker images for JCAST, a Python tool for generating al
 These Docker images are built from the Python 3.11 slim image and include:
 
 - JCAST v0.3.5: A tool for translating alternative splicing events (e.g., from rMATS output) into protein sequences for mass spectrometry-based proteomics
+- scikit-learn v1.6.1: Required dependency for JCAST's machine learning functionality
 
 The images are designed to be minimal and focused on JCAST with its dependencies.
 
@@ -70,7 +71,7 @@ The Dockerfile follows these main steps:
 1. Uses Python 3.11 slim as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs build dependencies (`gcc`, `g++`) needed to compile JCAST's `pomegranate` dependency
-4. Installs JCAST via pip with a pinned version and `--no-cache-dir`
+4. Installs scikit-learn and JCAST via pip with pinned versions and `--no-cache-dir`
 5. Removes build dependencies and cleans up apt lists to minimize image size
 
 ## Security Scanning and CVEs


### PR DESCRIPTION
## Summary
- Adds `scikit-learn==1.6.1` as an explicit dependency in jcast Dockerfiles
- Updates README to document the new dependency

## Context
The `jcast` Python package requires `sklearn` (scikit-learn) to function properly, but it's not listed in jcast's requirements file and doesn't get installed automatically via `pip install jcast`. This causes import errors at runtime.

## Changes
- `jcast/Dockerfile_latest`: Added scikit-learn to pip install
- `jcast/Dockerfile_0.3.5`: Added scikit-learn to pip install
- `jcast/README.md`: Updated Image Details and Dockerfile Structure sections

## Test plan
- [ ] Local Docker build succeeds
