### PR TITLE
Adding `r-utils` WILDS Docker image

### DIFF
--- a/r-utils/Dockerfile_0.1.0
+++ b/r-utils/Dockerfile_0.1.0
@@ -1,0 +1,26 @@
+
+# Use Rocker tidyverse base image
+FROM rocker/tidyverse:4
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="r-utils"
+LABEL org.opencontainers.image.description="Docker image for general-purpose R utilities in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install required R packages
+RUN R -e "install.packages(c('optparse', 'lubridate'), repos = 'https://cloud.r-project.org', dependencies = TRUE)"
+
+# Set working directory
+WORKDIR /data
+
+# Smoke test
+RUN R -e "library(optparse); library(lubridate)"

--- a/r-utils/Dockerfile_latest
+++ b/r-utils/Dockerfile_latest
@@ -1,0 +1,26 @@
+
+# Use Rocker tidyverse base image
+FROM rocker/tidyverse:4
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="r-utils"
+LABEL org.opencontainers.image.description="Docker image for general-purpose R utilities in FH DaSL's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install required R packages
+RUN R -e "install.packages(c('optparse', 'lubridate'), repos = 'https://cloud.r-project.org', dependencies = TRUE)"
+
+# Set working directory
+WORKDIR /data
+
+# Smoke test
+RUN R -e "library(optparse); library(lubridate)"

--- a/r-utils/README.md
+++ b/r-utils/README.md
@@ -1,0 +1,81 @@
+# r-utils
+
+This directory contains Docker images for r-utils, a general-purpose R environment built on Rocker/tidyverse with additional commonly used CRAN packages.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/r-utils/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/r-utils/CVEs_latest.md) )
+- `0.1.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/r-utils/Dockerfile_0.1.0) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/r-utils/CVEs_0.1.0.md) )
+
+## Image Details
+
+These Docker images are built from the Rocker/tidyverse:4 base image and include:
+
+- Tidyverse R packages: A collection of R packages for data science and analysis
+- optparse: For command-line argument parsing in R scripts
+- lubridate: For date-time manipulation
+
+The images are designed to provide a general-purpose R environment suitable for WILDS WDL modules that need tidyverse plus common utility packages.
+
+## Usage
+
+### Docker
+
+```bash
+docker pull getwilds/r-utils:latest
+# or
+docker pull getwilds/r-utils:0.1.0
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/r-utils:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+apptainer pull docker://getwilds/r-utils:latest
+# or
+apptainer pull docker://getwilds/r-utils:0.1.0
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/r-utils:latest
+```
+
+### Example Commands
+
+```bash
+# Run an R script with Docker
+docker run --rm -v /path/to/data:/data getwilds/r-utils:latest \
+  Rscript /data/analysis.R --input /data/input.csv --output /data/results.csv
+
+# Run an R script with Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/r-utils:latest \
+  Rscript /data/analysis.R --input /data/input.csv --output /data/results.csv
+
+# Apptainer (local SIF file)
+apptainer run --bind /path/to/data:/data r-utils_latest.sif \
+  Rscript /data/analysis.R --input /data/input.csv --output /data/results.csv
+```
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/tree/main/r-utils), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Rocker/tidyverse:4 as the base image, which provides R 4.x with tidyverse packages
+2. Adds metadata labels for documentation and attribution
+3. Sets R library paths to avoid host contamination in Apptainer
+4. Installs additional R packages (optparse, lubridate)
+5. Sets up a working directory for data analysis
+6. Runs a smoke test to verify package installation
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new `r-utils` Docker image — a general-purpose R environment built on `rocker/tidyverse:4` with `optparse` and `lubridate` pre-installed. This image will initially be used by the `ww-sjl` WDL module in the WILDS WDL Library (which runs `sjl_tiles.R` for geographic tile processing in the Solar Jetlag pipeline), but is named generically so it can serve any WDL module needing a tidyverse + common utilities R environment.

### Files added
- `r-utils/Dockerfile_0.1.0`
- `r-utils/Dockerfile_latest`
- `r-utils/README.md`

## Testing

**How did you test these changes?**
Ran `make validate IMAGE=r-utils`

**Did the tests pass?**
Yes

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=r-utils`
- [x] Image builds successfully for target platform(s)