### PR TITLE
Keep wget in image, update versions of utilities

### DIFF
--- a/ena-tools/Dockerfile_2.1.1
+++ b/ena-tools/Dockerfile_2.1.1
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 ENV ENA_DOWNLOADER_VERSION=2.1.1
 
 # Download and install ENA FTP Downloader
-RUN apk add --no-cache wget=1.25.0-r1 unzip=6.0-r15 bash=5.2.37-r0 \
+RUN apk add --no-cache wget=1.25.0-r2 unzip=6.0-r16 bash=5.3.3-r1 \
   && wget -q https://ftp.ebi.ac.uk/pub/databases/ena/tools/ena-file-downloader.zip \
   && unzip ena-file-downloader.zip \
   && mv ena-file-downloader.jar /usr/local/bin/ \

--- a/ena-tools/Dockerfile_latest
+++ b/ena-tools/Dockerfile_latest
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses=MIT
 ENV ENA_DOWNLOADER_VERSION=2.1.1
 
 # Download and install ENA FTP Downloader
-RUN apk add --no-cache wget=1.25.0-r1 unzip=6.0-r15 bash=5.2.37-r0 \
+RUN apk add --no-cache wget=1.25.0-r2 unzip=6.0-r16 bash=5.3.3-r1 \
   && wget -q https://ftp.ebi.ac.uk/pub/databases/ena/tools/ena-file-downloader.zip \
   && unzip ena-file-downloader.zip \
   && mv ena-file-downloader.jar /usr/local/bin/ \


### PR DESCRIPTION
## Type of Change

- Version update (only of `wget`, `unzip`, `bash`)

## Description

- Removed `wget` from list of packages to be removed
- Updated versions of `wget`, `unzip`, and `bash` to install (because the ones we have aren't available anymore)

## Related Issue

Fixes #337 

## Testing

**How did you test these changes?**
Built the image locally and then ran interactively:

```
docker run -it ena-tools:latest /bin/bash
```

Ran these commands inside the image which worked fine:
```
java -jar /usr/local/bin/ena-file-downloader.jar --accessions=ERR10825982 --format=READS_FASTQ --protocol=FTP --location="."
```
```
wget
```

**Did the tests pass?**
Yes, it downloaded the files and I got the `wget` help menu.

## Checklist

- [X] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [X] All required OCI metadata labels are present and accurate
- [X] `README.md` is included/updated in the tool directory
- [X] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [X] Image builds successfully for target platform(s)

## Additional Context

I need wget to use http ENA urls (see https://github.com/getwilds/wilds-wdl-library/issues/235)
