### PR TITLE
Adding initial version of MultiQC WILDS Docker image

### DIFF
--- a/multiqc/CVEs_1.33.md
+++ b/multiqc/CVEs_1.33.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/multiqc:1.33
+
+Report generated on 2026-03-27 23:06:33 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 24 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `python:3.13-slim`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 23 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.14-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/multiqc:1.33-amd64  │    0C     0H     2M    24L  
+   digest           │  034a1b63b308                         │                             
+ Base image         │  python:3.13-slim                     │    0C     0H     2M    23L  
+ Updated base image │  python:3.14-slim                     │    0C     0H     2M    23L  
+                    │                                       │                             
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/multiqc:1.33-amd64
+    View base image update recommendations → docker scout recommendations getwilds/multiqc:1.33-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/multiqc:1.33-amd64 --org <organization>
+```
+</details>

--- a/multiqc/CVEs_latest.md
+++ b/multiqc/CVEs_latest.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/multiqc:latest
+
+Report generated on 2026-03-27 23:15:20 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 24 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `python:3.13-slim`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 23 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.14-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/multiqc:latest-amd64  │    0C     0H     2M    24L  
+   digest           │  ea91772e0c77                           │                             
+ Base image         │  python:3.13-slim                       │    0C     0H     2M    23L  
+ Updated base image │  python:3.14-slim                       │    0C     0H     2M    23L  
+                    │                                         │                             
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/multiqc:latest-amd64
+    View base image update recommendations → docker scout recommendations getwilds/multiqc:latest-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/multiqc:latest-amd64 --org <organization>
+```
+</details>

--- a/multiqc/Dockerfile_1.33
+++ b/multiqc/Dockerfile_1.33
@@ -1,0 +1,28 @@
+# Using Python slim base image
+FROM python:3.13-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="multiqc"
+LABEL org.opencontainers.image.description="Docker image for MultiQC in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="1.33"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Configuring shell for better error handling
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing system dependencies with pinned versions
+RUN apt-get update \
+  && PROCPS_VERSION=$(apt-cache policy procps | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  procps="${PROCPS_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Installing MultiQC via pip
+RUN pip install --no-cache-dir multiqc==1.33
+
+# Smoke test
+RUN multiqc --version

--- a/multiqc/Dockerfile_latest
+++ b/multiqc/Dockerfile_latest
@@ -1,0 +1,28 @@
+# Using Python slim base image
+FROM python:3.13-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="multiqc"
+LABEL org.opencontainers.image.description="Docker image for MultiQC in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Configuring shell for better error handling
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing system dependencies with pinned versions
+RUN apt-get update \
+  && PROCPS_VERSION=$(apt-cache policy procps | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  procps="${PROCPS_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Installing MultiQC via pip
+RUN pip install --no-cache-dir multiqc==1.33
+
+# Smoke test
+RUN multiqc --version

--- a/multiqc/README.md
+++ b/multiqc/README.md
@@ -1,0 +1,107 @@
+# MultiQC
+
+This directory contains Docker images for [MultiQC](https://seqera.io/multiqc/), a tool for aggregating quality control results from bioinformatics analyses across many samples into a single interactive HTML report.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/multiqc/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/multiqc/CVEs_latest.md) )
+- `1.33` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/multiqc/Dockerfile_1.33) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/multiqc/CVEs_1.33.md) )
+
+## Image Details
+
+These Docker images are built from `python:3.13-slim` and include:
+
+- MultiQC v1.33: Aggregates results from 150+ bioinformatics tools into a single report
+- procps: Process utilities (included for pipeline compatibility)
+
+The images are designed to be minimal and focused on MultiQC with its essential dependencies.
+
+## Citation
+
+If you use MultiQC in your research, please cite the original authors:
+
+```
+Ewels P, Magnusson M, Lundin S, Kaller M. MultiQC: summarize analysis results
+for multiple tools and samples in a single report. Bioinformatics. 2016;32(19):3047-3048.
+doi:10.1093/bioinformatics/btw354
+```
+
+**Tool homepage:** https://seqera.io/multiqc/
+
+**Publication:** https://doi.org/10.1093/bioinformatics/btw354
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/multiqc:latest
+
+# Or pull a specific version
+docker pull getwilds/multiqc:1.33
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/multiqc:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/multiqc:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/multiqc:1.33
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/multiqc:latest
+```
+
+### Example Commands
+
+```bash
+# Generate a report from all tool outputs in a directory
+docker run --rm -v /path/to/data:/data getwilds/multiqc:latest \
+  multiqc /data --outdir /data/multiqc_report
+
+# Generate a report with a custom title
+docker run --rm -v /path/to/data:/data getwilds/multiqc:latest \
+  multiqc /data --outdir /data/multiqc_report --title "My Experiment QC"
+
+# Run on specific directories only
+docker run --rm -v /path/to/data:/data getwilds/multiqc:latest \
+  multiqc /data/fastqc /data/star --outdir /data/multiqc_report
+
+# Generate a flat image report (no interactive plots)
+docker run --rm -v /path/to/data:/data getwilds/multiqc:latest \
+  multiqc /data --flat --outdir /data/multiqc_report
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/multiqc:latest \
+  multiqc /data --outdir /data/multiqc_report
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses `python:3.13-slim` as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs system dependencies (procps) with pinned versions
+4. Installs MultiQC via pip with `--no-cache-dir`
+5. Runs a smoke test to verify the installation
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/multiqc), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.
+
+---


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new Docker image for [MultiQC](https://seqera.io/multiqc/) v1.33, a bioinformatics tool that aggregates quality control results from 150+ analysis tools into a single interactive HTML report.

- **Base image:** `python:3.13-slim`
- **Installation method:** `pip install --no-cache-dir multiqc==1.33`
- **System dependency:** `procps` (included for Nextflow/pipeline compatibility)
- **Tags:** `latest`, `1.33`

## Testing

**How did you test these changes?**

Ran `make lint IMAGE=multiqc` and `make build_amd64 IMAGE=multiqc`.

**Did the tests pass?**

Yes.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)