### PR TITLE
Adding initial version of ViennaRNA WILDS Docker Image

### DIFF
--- a/viennarna/CVEs_2.7.2.md
+++ b/viennarna/CVEs_2.7.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/viennarna:2.7.2
 
-Report generated on 2026-04-07 17:17:17 PST
+Report generated on 2026-04-14 06:23:02 PST
 
 ## Platform Coverage
 
@@ -11,21 +11,21 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 | Severity | Count |
 |----------|-------|
 | 🔴 Critical | 0 |
-| 🟠 High | 7 |
-| 🟡 Medium | 19 |
-| 🟢 Low | 6 |
+| 🟠 High | 0 |
+| 🟡 Medium | 1 |
+| 🟢 Low | 2 |
 | ⚪ Unknown | 0 |
 
 ## 🐳 Base Image
 
-**Image:** `ubuntu:20.04`
+**Image:** `ubuntu:24.04`
 
 | Severity | Count |
 |----------|-------|
 | 🔴 Critical | 0 |
 | 🟠 High | 0 |
-| 🟡 Medium | 5 |
-| 🟢 Low | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 7 |
 
 ## 🔄 Recommendations
 
@@ -35,11 +35,11 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target             │  getwilds/viennarna:2.7.2-amd64  │    0C     7H    19M     6L  
-   digest           │  9cde5535d634                            │                             
- Base image         │  ubuntu:20.04                            │    0C     0H     5M     0L  
+Target             │  getwilds/viennarna:2.7.2-amd64  │    0C     0H     1M     2L  
+   digest           │  2a7115df7d7e                            │                             
+ Base image         │  ubuntu:24.04                            │    0C     0H     2M     7L  
  Updated base image │  ubuntu:25.10                            │    0C     0H     0M     0L  
-                    │                                          │                  -5         
+                    │                                          │                  -2     -7  
 
 What's next:
     View vulnerabilities → docker scout cves getwilds/viennarna:2.7.2-amd64

--- a/viennarna/CVEs_2.7.2.md
+++ b/viennarna/CVEs_2.7.2.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/viennarna:2.7.2
+
+Report generated on 2026-04-07 17:17:17 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 7 |
+| 🟡 Medium | 19 |
+| 🟢 Low | 6 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `ubuntu:20.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 5 |
+| 🟢 Low | 0 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `ubuntu:25.10`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/viennarna:2.7.2-amd64  │    0C     7H    19M     6L  
+   digest           │  9cde5535d634                            │                             
+ Base image         │  ubuntu:20.04                            │    0C     0H     5M     0L  
+ Updated base image │  ubuntu:25.10                            │    0C     0H     0M     0L  
+                    │                                          │                  -5         
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/viennarna:2.7.2-amd64
+    View base image update recommendations → docker scout recommendations getwilds/viennarna:2.7.2-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/viennarna:2.7.2-amd64 --org <organization>
+```
+</details>

--- a/viennarna/CVEs_latest.md
+++ b/viennarna/CVEs_latest.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/viennarna:latest
+
+Report generated on 2026-04-07 17:22:17 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 7 |
+| 🟡 Medium | 19 |
+| 🟢 Low | 6 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `ubuntu:20.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 5 |
+| 🟢 Low | 0 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `ubuntu:25.10`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/viennarna:latest-amd64  │    0C     7H    19M     6L  
+   digest           │  dd96cfa771f3                             │                             
+ Base image         │  ubuntu:20.04                             │    0C     0H     5M     0L  
+ Updated base image │  ubuntu:25.10                             │    0C     0H     0M     0L  
+                    │                                           │                  -5         
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/viennarna:latest-amd64
+    View base image update recommendations → docker scout recommendations getwilds/viennarna:latest-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/viennarna:latest-amd64 --org <organization>
+```
+</details>

--- a/viennarna/CVEs_latest.md
+++ b/viennarna/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/viennarna:latest
 
-Report generated on 2026-04-07 17:22:17 PST
+Report generated on 2026-04-14 07:06:36 PST
 
 ## Platform Coverage
 
@@ -11,21 +11,21 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 | Severity | Count |
 |----------|-------|
 | 🔴 Critical | 0 |
-| 🟠 High | 7 |
-| 🟡 Medium | 19 |
-| 🟢 Low | 6 |
+| 🟠 High | 0 |
+| 🟡 Medium | 1 |
+| 🟢 Low | 2 |
 | ⚪ Unknown | 0 |
 
 ## 🐳 Base Image
 
-**Image:** `ubuntu:20.04`
+**Image:** `ubuntu:24.04`
 
 | Severity | Count |
 |----------|-------|
 | 🔴 Critical | 0 |
 | 🟠 High | 0 |
-| 🟡 Medium | 5 |
-| 🟢 Low | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 7 |
 
 ## 🔄 Recommendations
 
@@ -35,11 +35,11 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target             │  getwilds/viennarna:latest-amd64  │    0C     7H    19M     6L  
-   digest           │  dd96cfa771f3                             │                             
- Base image         │  ubuntu:20.04                             │    0C     0H     5M     0L  
+Target             │  getwilds/viennarna:latest-amd64  │    0C     0H     1M     2L  
+   digest           │  3037acc467f0                             │                             
+ Base image         │  ubuntu:24.04                             │    0C     0H     2M     7L  
  Updated base image │  ubuntu:25.10                             │    0C     0H     0M     0L  
-                    │                                           │                  -5         
+                    │                                           │                  -2     -7  
 
 What's next:
     View vulnerabilities → docker scout cves getwilds/viennarna:latest-amd64

--- a/viennarna/Dockerfile_2.7.2
+++ b/viennarna/Dockerfile_2.7.2
@@ -17,9 +17,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Build ViennaRNA from upstream source. Bindings (Python/Perl/R/Swig) are
-# disabled to keep the image slim and avoid pulling in extra toolchains;
-# the CLI programs (RNAfold, RNAalifold, RNAeval, ...) are what we need.
+# Install pinned build and runtime dependencies, then fetch the ViennaRNA
+# source tarball. Build deps are purged in a later layer once the CLI tools
+# have been compiled and installed.
 RUN apt-get update \
   && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
   && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
@@ -50,11 +50,19 @@ RUN apt-get update \
   liblapack3="${LIBLAPACK3_VERSION}" \
   liblapacke="${LIBLAPACKE_RT_VERSION}" \
   libstdc++6="${LIBSTDCPP6_VERSION}" \
+  && rm -rf /var/lib/apt/lists/* \
   && wget -q --no-check-certificate \
   https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_7_x/ViennaRNA-2.7.2.tar.gz \
   && tar -xzf ViennaRNA-2.7.2.tar.gz \
-  && cd ViennaRNA-2.7.2 \
-  && ./configure \
+  && rm -f ViennaRNA-2.7.2.tar.gz
+
+# Configure and build ViennaRNA. Language bindings (Python/Perl/R/Swig) are
+# disabled to keep the image slim and avoid pulling in extra toolchains;
+# the CLI programs (RNAfold, RNAalifold, RNAeval, ...) are what we need.
+# --disable-lto avoids an internal compiler error seen when cross-building
+# under QEMU emulation; the runtime cost is negligible for RNA folding.
+WORKDIR /ViennaRNA-2.7.2
+RUN ./configure \
   --disable-lto \
   --without-swig \
   --without-perl \
@@ -64,9 +72,11 @@ RUN apt-get update \
   --without-kinfold \
   --without-rnalocmin \
   && make -j"$(nproc)" \
-  && make install \
-  && cd / \
-  && rm -rf ViennaRNA-2.7.2 ViennaRNA-2.7.2.tar.gz \
+  && make install
+
+# Remove source tree and purge build-only packages to minimize image size
+WORKDIR /
+RUN rm -rf /ViennaRNA-2.7.2 \
   && apt-get purge -y --auto-remove \
   build-essential wget ca-certificates pkg-config \
   libgsl-dev libmpfr-dev liblapack-dev liblapacke-dev \

--- a/viennarna/Dockerfile_2.7.2
+++ b/viennarna/Dockerfile_2.7.2
@@ -1,0 +1,27 @@
+# ViennaRNA Dockerfile for WILDS Docker Library
+# ViennaRNA: RNA secondary structure prediction and comparison
+FROM condaforge/miniforge3:24.7.1-2
+
+# Adding labels for the GitHub Container Registry following WILDS standards
+LABEL org.opencontainers.image.title="viennarna"
+LABEL org.opencontainers.image.description="Docker image for ViennaRNA in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="2.7.2"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install ViennaRNA via bioconda with pinned version
+RUN mamba install -y -c bioconda -c conda-forge \
+  viennarna=2.7.2 \
+  && mamba clean -afy
+
+# Smoke test to verify ViennaRNA is installed correctly
+RUN RNAfold --version && RNAalifold --version && RNAeval --version
+
+# Set working directory
+WORKDIR /data

--- a/viennarna/Dockerfile_2.7.2
+++ b/viennarna/Dockerfile_2.7.2
@@ -1,6 +1,6 @@
 # ViennaRNA Dockerfile for WILDS Docker Library
 # ViennaRNA: RNA secondary structure prediction and comparison
-FROM condaforge/miniforge3:24.7.1-2
+FROM ubuntu:24.04
 
 # Adding labels for the GitHub Container Registry following WILDS standards
 LABEL org.opencontainers.image.title="viennarna"
@@ -15,10 +15,62 @@ LABEL org.opencontainers.image.licenses=MIT
 # Set the shell option to fail if any command in a pipe fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install ViennaRNA via bioconda with pinned version
-RUN mamba install -y -c bioconda -c conda-forge \
-  viennarna=2.7.2 \
-  && mamba clean -afy
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build ViennaRNA from upstream source. Bindings (Python/Perl/R/Swig) are
+# disabled to keep the image slim and avoid pulling in extra toolchains;
+# the CLI programs (RNAfold, RNAalifold, RNAeval, ...) are what we need.
+RUN apt-get update \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && CA_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
+  && PKGCONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
+  && LIBGSL_VERSION=$(apt-cache policy libgsl-dev | grep Candidate | awk '{print $2}') \
+  && LIBMPFR_VERSION=$(apt-cache policy libmpfr-dev | grep Candidate | awk '{print $2}') \
+  && LIBLAPACK_VERSION=$(apt-cache policy liblapack-dev | grep Candidate | awk '{print $2}') \
+  && LIBLAPACKE_VERSION=$(apt-cache policy liblapacke-dev | grep Candidate | awk '{print $2}') \
+  && LIBGOMP1_VERSION=$(apt-cache policy libgomp1 | grep Candidate | awk '{print $2}') \
+  && LIBGSL27_VERSION=$(apt-cache policy libgsl27 | grep Candidate | awk '{print $2}') \
+  && LIBMPFR6_VERSION=$(apt-cache policy libmpfr6 | grep Candidate | awk '{print $2}') \
+  && LIBLAPACK3_VERSION=$(apt-cache policy liblapack3 | grep Candidate | awk '{print $2}') \
+  && LIBLAPACKE_RT_VERSION=$(apt-cache policy liblapacke | grep Candidate | awk '{print $2}') \
+  && LIBSTDCPP6_VERSION=$(apt-cache policy libstdc++6 | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  wget="${WGET_VERSION}" \
+  ca-certificates="${CA_VERSION}" \
+  pkg-config="${PKGCONFIG_VERSION}" \
+  libgsl-dev="${LIBGSL_VERSION}" \
+  libmpfr-dev="${LIBMPFR_VERSION}" \
+  liblapack-dev="${LIBLAPACK_VERSION}" \
+  liblapacke-dev="${LIBLAPACKE_VERSION}" \
+  libgomp1="${LIBGOMP1_VERSION}" \
+  libgsl27="${LIBGSL27_VERSION}" \
+  libmpfr6="${LIBMPFR6_VERSION}" \
+  liblapack3="${LIBLAPACK3_VERSION}" \
+  liblapacke="${LIBLAPACKE_RT_VERSION}" \
+  libstdc++6="${LIBSTDCPP6_VERSION}" \
+  && wget -q --no-check-certificate \
+  https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_7_x/ViennaRNA-2.7.2.tar.gz \
+  && tar -xzf ViennaRNA-2.7.2.tar.gz \
+  && cd ViennaRNA-2.7.2 \
+  && ./configure \
+  --disable-lto \
+  --without-swig \
+  --without-perl \
+  --without-python \
+  --without-doc \
+  --without-forester \
+  --without-kinfold \
+  --without-rnalocmin \
+  && make -j"$(nproc)" \
+  && make install \
+  && cd / \
+  && rm -rf ViennaRNA-2.7.2 ViennaRNA-2.7.2.tar.gz \
+  && apt-get purge -y --auto-remove \
+  build-essential wget ca-certificates pkg-config \
+  libgsl-dev libmpfr-dev liblapack-dev liblapacke-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # Smoke test to verify ViennaRNA is installed correctly
 RUN RNAfold --version && RNAalifold --version && RNAeval --version

--- a/viennarna/Dockerfile_latest
+++ b/viennarna/Dockerfile_latest
@@ -17,9 +17,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Build ViennaRNA from upstream source. Bindings (Python/Perl/R/Swig) are
-# disabled to keep the image slim and avoid pulling in extra toolchains;
-# the CLI programs (RNAfold, RNAalifold, RNAeval, ...) are what we need.
+# Install pinned build and runtime dependencies, then fetch the ViennaRNA
+# source tarball. Build deps are purged in a later layer once the CLI tools
+# have been compiled and installed.
 RUN apt-get update \
   && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
   && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
@@ -50,11 +50,19 @@ RUN apt-get update \
   liblapack3="${LIBLAPACK3_VERSION}" \
   liblapacke="${LIBLAPACKE_RT_VERSION}" \
   libstdc++6="${LIBSTDCPP6_VERSION}" \
+  && rm -rf /var/lib/apt/lists/* \
   && wget -q --no-check-certificate \
   https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_7_x/ViennaRNA-2.7.2.tar.gz \
   && tar -xzf ViennaRNA-2.7.2.tar.gz \
-  && cd ViennaRNA-2.7.2 \
-  && ./configure \
+  && rm -f ViennaRNA-2.7.2.tar.gz
+
+# Configure and build ViennaRNA. Language bindings (Python/Perl/R/Swig) are
+# disabled to keep the image slim and avoid pulling in extra toolchains;
+# the CLI programs (RNAfold, RNAalifold, RNAeval, ...) are what we need.
+# --disable-lto avoids an internal compiler error seen when cross-building
+# under QEMU emulation; the runtime cost is negligible for RNA folding.
+WORKDIR /ViennaRNA-2.7.2
+RUN ./configure \
   --disable-lto \
   --without-swig \
   --without-perl \
@@ -64,9 +72,11 @@ RUN apt-get update \
   --without-kinfold \
   --without-rnalocmin \
   && make -j"$(nproc)" \
-  && make install \
-  && cd / \
-  && rm -rf ViennaRNA-2.7.2 ViennaRNA-2.7.2.tar.gz \
+  && make install
+
+# Remove source tree and purge build-only packages to minimize image size
+WORKDIR /
+RUN rm -rf /ViennaRNA-2.7.2 \
   && apt-get purge -y --auto-remove \
   build-essential wget ca-certificates pkg-config \
   libgsl-dev libmpfr-dev liblapack-dev liblapacke-dev \

--- a/viennarna/Dockerfile_latest
+++ b/viennarna/Dockerfile_latest
@@ -1,0 +1,27 @@
+# ViennaRNA Dockerfile for WILDS Docker Library
+# ViennaRNA: RNA secondary structure prediction and comparison
+FROM condaforge/miniforge3:24.7.1-2
+
+# Adding labels for the GitHub Container Registry following WILDS standards
+LABEL org.opencontainers.image.title="viennarna"
+LABEL org.opencontainers.image.description="Docker image for ViennaRNA in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install ViennaRNA via bioconda with pinned version
+RUN mamba install -y -c bioconda -c conda-forge \
+  viennarna=2.7.2 \
+  && mamba clean -afy
+
+# Smoke test to verify ViennaRNA is installed correctly
+RUN RNAfold --version && RNAalifold --version && RNAeval --version
+
+# Set working directory
+WORKDIR /data

--- a/viennarna/Dockerfile_latest
+++ b/viennarna/Dockerfile_latest
@@ -1,6 +1,6 @@
 # ViennaRNA Dockerfile for WILDS Docker Library
 # ViennaRNA: RNA secondary structure prediction and comparison
-FROM condaforge/miniforge3:24.7.1-2
+FROM ubuntu:24.04
 
 # Adding labels for the GitHub Container Registry following WILDS standards
 LABEL org.opencontainers.image.title="viennarna"
@@ -15,10 +15,62 @@ LABEL org.opencontainers.image.licenses=MIT
 # Set the shell option to fail if any command in a pipe fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install ViennaRNA via bioconda with pinned version
-RUN mamba install -y -c bioconda -c conda-forge \
-  viennarna=2.7.2 \
-  && mamba clean -afy
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build ViennaRNA from upstream source. Bindings (Python/Perl/R/Swig) are
+# disabled to keep the image slim and avoid pulling in extra toolchains;
+# the CLI programs (RNAfold, RNAalifold, RNAeval, ...) are what we need.
+RUN apt-get update \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && CA_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
+  && PKGCONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
+  && LIBGSL_VERSION=$(apt-cache policy libgsl-dev | grep Candidate | awk '{print $2}') \
+  && LIBMPFR_VERSION=$(apt-cache policy libmpfr-dev | grep Candidate | awk '{print $2}') \
+  && LIBLAPACK_VERSION=$(apt-cache policy liblapack-dev | grep Candidate | awk '{print $2}') \
+  && LIBLAPACKE_VERSION=$(apt-cache policy liblapacke-dev | grep Candidate | awk '{print $2}') \
+  && LIBGOMP1_VERSION=$(apt-cache policy libgomp1 | grep Candidate | awk '{print $2}') \
+  && LIBGSL27_VERSION=$(apt-cache policy libgsl27 | grep Candidate | awk '{print $2}') \
+  && LIBMPFR6_VERSION=$(apt-cache policy libmpfr6 | grep Candidate | awk '{print $2}') \
+  && LIBLAPACK3_VERSION=$(apt-cache policy liblapack3 | grep Candidate | awk '{print $2}') \
+  && LIBLAPACKE_RT_VERSION=$(apt-cache policy liblapacke | grep Candidate | awk '{print $2}') \
+  && LIBSTDCPP6_VERSION=$(apt-cache policy libstdc++6 | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  wget="${WGET_VERSION}" \
+  ca-certificates="${CA_VERSION}" \
+  pkg-config="${PKGCONFIG_VERSION}" \
+  libgsl-dev="${LIBGSL_VERSION}" \
+  libmpfr-dev="${LIBMPFR_VERSION}" \
+  liblapack-dev="${LIBLAPACK_VERSION}" \
+  liblapacke-dev="${LIBLAPACKE_VERSION}" \
+  libgomp1="${LIBGOMP1_VERSION}" \
+  libgsl27="${LIBGSL27_VERSION}" \
+  libmpfr6="${LIBMPFR6_VERSION}" \
+  liblapack3="${LIBLAPACK3_VERSION}" \
+  liblapacke="${LIBLAPACKE_RT_VERSION}" \
+  libstdc++6="${LIBSTDCPP6_VERSION}" \
+  && wget -q --no-check-certificate \
+  https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_7_x/ViennaRNA-2.7.2.tar.gz \
+  && tar -xzf ViennaRNA-2.7.2.tar.gz \
+  && cd ViennaRNA-2.7.2 \
+  && ./configure \
+  --disable-lto \
+  --without-swig \
+  --without-perl \
+  --without-python \
+  --without-doc \
+  --without-forester \
+  --without-kinfold \
+  --without-rnalocmin \
+  && make -j"$(nproc)" \
+  && make install \
+  && cd / \
+  && rm -rf ViennaRNA-2.7.2 ViennaRNA-2.7.2.tar.gz \
+  && apt-get purge -y --auto-remove \
+  build-essential wget ca-certificates pkg-config \
+  libgsl-dev libmpfr-dev liblapack-dev liblapacke-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # Smoke test to verify ViennaRNA is installed correctly
 RUN RNAfold --version && RNAalifold --version && RNAeval --version

--- a/viennarna/README.md
+++ b/viennarna/README.md
@@ -9,12 +9,11 @@ This directory contains Docker images for [ViennaRNA](https://www.tbi.univie.ac.
 
 ## Image Details
 
-These Docker images are built from `condaforge/miniforge3:24.7.1-2` and include:
+These Docker images are built from `ubuntu:24.04` and include:
 
 - ViennaRNA v2.7.2: A comprehensive suite of tools for RNA secondary structure prediction, partition function calculations, suboptimal structure enumeration, RNA-RNA interaction prediction, and sequence design
-- Python and Perl bindings for programmatic access to the ViennaRNA library
 
-The images are designed to be minimal and focused on ViennaRNA with its essential dependencies.
+ViennaRNA is compiled from upstream source with the Python, Perl, and SWIG bindings disabled to keep the image focused on the command-line tools (`RNAfold`, `RNAalifold`, `RNAeval`, `RNAsubopt`, `RNAinverse`, etc.) and minimize image size. If you need the language bindings, please file an issue.
 
 ## Citation
 
@@ -88,11 +87,13 @@ echo "GGGAAAUCC" | apptainer run docker://getwilds/viennarna:latest RNAfold
 
 The Dockerfile follows these main steps:
 
-1. Uses `condaforge/miniforge3:24.7.1-2` as the base image
+1. Uses `ubuntu:24.04` as the base image
 2. Adds metadata labels for documentation and attribution
-3. Installs ViennaRNA v2.7.2 via mamba from the bioconda channel
-4. Runs smoke tests to verify RNAfold, RNAalifold, and RNAeval are functional
-5. Performs cleanup with `mamba clean -afy` to minimize image size
+3. Installs pinned build and runtime dependencies (`build-essential`, `libgsl-dev`, `libmpfr-dev`, `liblapack-dev`, `liblapacke-dev`, and their runtime counterparts) via `apt-get`
+4. Downloads the ViennaRNA v2.7.2 source tarball from the official TBI Vienna download site
+5. Configures the build with `--disable-lto` and `--without-{swig,perl,python,doc,forester,kinfold,rnalocmin}`, then compiles and installs via `make && make install`
+6. Runs smoke tests to verify RNAfold, RNAalifold, and RNAeval are functional
+7. Purges the build-only packages and removes source artifacts and apt lists to minimize image size
 
 ## Security Scanning and CVEs
 

--- a/viennarna/README.md
+++ b/viennarna/README.md
@@ -1,0 +1,109 @@
+# ViennaRNA
+
+This directory contains Docker images for [ViennaRNA](https://www.tbi.univie.ac.at/RNA/), a widely used package for RNA secondary structure prediction, comparison, and analysis.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/viennarna/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/viennarna/CVEs_latest.md) )
+- `2.7.2` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/viennarna/Dockerfile_2.7.2) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/viennarna/CVEs_2.7.2.md) )
+
+## Image Details
+
+These Docker images are built from `condaforge/miniforge3:24.7.1-2` and include:
+
+- ViennaRNA v2.7.2: A comprehensive suite of tools for RNA secondary structure prediction, partition function calculations, suboptimal structure enumeration, RNA-RNA interaction prediction, and sequence design
+- Python and Perl bindings for programmatic access to the ViennaRNA library
+
+The images are designed to be minimal and focused on ViennaRNA with its essential dependencies.
+
+## Citation
+
+If you use ViennaRNA in your research, please cite the original authors:
+
+```
+Lorenz, R., Bernhart, S.H., Höner zu Siederdissen, C., Tafer, H., Flamm, C.,
+Stadler, P.F. and Hofacker, I.L. (2011). ViennaRNA Package 2.0.
+Algorithms for Molecular Biology, 6:26.
+https://doi.org/10.1186/1748-7188-6-26
+```
+
+**Tool homepage:** https://www.tbi.univie.ac.at/RNA/
+
+**GitHub:** https://github.com/ViennaRNA/ViennaRNA
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/viennarna:latest
+
+# Or pull a specific version
+docker pull getwilds/viennarna:2.7.2
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/viennarna:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/viennarna:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/viennarna:2.7.2
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/viennarna:latest
+```
+
+### Example Commands
+
+```bash
+# Predict minimum free energy (MFE) structure of an RNA sequence
+echo "GGGAAAUCC" | docker run --rm -i getwilds/viennarna:latest RNAfold
+
+# Predict MFE structure from a FASTA file
+docker run --rm -v /path/to/data:/data getwilds/viennarna:latest \
+  RNAfold --infile=/data/sequences.fa --outfile=/data/structures.txt
+
+# Compute suboptimal structures within 5 kcal/mol of MFE
+echo "GGGAAAUCC" | docker run --rm -i getwilds/viennarna:latest \
+  RNAsubopt -e 5
+
+# Predict consensus structure from a multiple sequence alignment
+docker run --rm -v /path/to/data:/data getwilds/viennarna:latest \
+  RNAalifold /data/alignment.aln
+
+# Design a sequence that folds into a target structure (inverse folding)
+echo "(((...)))" | docker run --rm -i getwilds/viennarna:latest RNAinverse
+
+# Alternatively using Apptainer
+echo "GGGAAAUCC" | apptainer run docker://getwilds/viennarna:latest RNAfold
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses `condaforge/miniforge3:24.7.1-2` as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs ViennaRNA v2.7.2 via mamba from the bioconda channel
+4. Runs smoke tests to verify RNAfold, RNAalifold, and RNAeval are functional
+5. Performs cleanup with `mamba clean -afy` to minimize image size
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/viennarna), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.
+
+---

--- a/viennarna/README.md
+++ b/viennarna/README.md
@@ -62,14 +62,14 @@ apptainer pull docker://ghcr.io/getwilds/viennarna:latest
 
 ```bash
 # Predict minimum free energy (MFE) structure of an RNA sequence
-echo "GGGAAAUCC" | docker run --rm -i getwilds/viennarna:latest RNAfold
+echo "GAGUAGUGGAACCAGGCUAUGUUUGUGACUCGCAGACUAACA" | docker run --rm -i getwilds/viennarna:latest RNAfold
 
 # Predict MFE structure from a FASTA file
 docker run --rm -v /path/to/data:/data getwilds/viennarna:latest \
   RNAfold --infile=/data/sequences.fa --outfile=/data/structures.txt
 
 # Compute suboptimal structures within 5 kcal/mol of MFE
-echo "GGGAAAUCC" | docker run --rm -i getwilds/viennarna:latest \
+echo "GAGUAGUGGAACCAGGCUAUGUUUGUGACUCGCAGACUAACA" | docker run --rm -i getwilds/viennarna:latest \
   RNAsubopt -e 5
 
 # Predict consensus structure from a multiple sequence alignment
@@ -80,7 +80,7 @@ docker run --rm -v /path/to/data:/data getwilds/viennarna:latest \
 echo "(((...)))" | docker run --rm -i getwilds/viennarna:latest RNAinverse
 
 # Alternatively using Apptainer
-echo "GGGAAAUCC" | apptainer run docker://getwilds/viennarna:latest RNAfold
+echo "GAGUAGUGGAACCAGGCUAUGUUUGUGACUCGCAGACUAACA" | apptainer run docker://getwilds/viennarna:latest RNAfold
 ```
 
 ## Dockerfile Structure


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Add ViennaRNA v2.7.2 Docker image for RNA secondary structure prediction and comparison. ViennaRNA is a widely used package providing tools like RNAfold, RNAalifold, RNAsubopt, and RNAinverse for predicting minimum free energy structures, partition functions, suboptimal structures, and inverse folding.

- **Base image:** `condaforge/miniforge3:24.7.1-2`
- **Installation method:** mamba from bioconda channel (pinned to v2.7.2)
- **Smoke tests:** RNAfold, RNAalifold, and RNAeval version checks

## Testing

**How did you test these changes?**

Ran `make lint IMAGE=viennarna` — passed clean with no hadolint warnings.
Built via manually triggered run of build-and-push GitHub Action

**Did the tests pass?**

Lint and build tests passed.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

- Chose bioconda/mamba over compiling from source to avoid a heavy build toolchain (swig, gcc, perl, etc.) and keep the image small
- ViennaRNA is available on bioconda with multi-arch support (linux-aarch64), so it does not need to be added to `amd64_only_tools.txt`
- README includes citation for Lorenz et al. (2011), Algorithms for Molecular Biology, 6:26
