### PR TITLE
Adding initial version of popV WILDS Docker image

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -9,6 +9,7 @@ flax
 hisat2
 manta
 megahit
+popv
 python-dl
 rmats-turbo
 rtorch

--- a/popv/CVEs_0.6.1.md
+++ b/popv/CVEs_0.6.1.md
@@ -1,0 +1,20 @@
+# Vulnerability Report for getwilds/popv:0.6.1
+
+Report generated on 2026-04-14 17:39:57 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## ⚠️ Scan Skipped - Image Too Large
+
+Docker Scout scan was skipped for this image because it exceeds the size limit.
+
+**Image size:** 4.0 GB
+**Size limit:** 3.0 GB
+
+Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
+
+```bash
+docker scout quickview getwilds/popv:0.6.1 --platform linux/amd64
+```

--- a/popv/CVEs_latest.md
+++ b/popv/CVEs_latest.md
@@ -1,0 +1,20 @@
+# Vulnerability Report for getwilds/popv:latest
+
+Report generated on 2026-04-14 17:54:59 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## ⚠️ Scan Skipped - Image Too Large
+
+Docker Scout scan was skipped for this image because it exceeds the size limit.
+
+**Image size:** 4.0 GB
+**Size limit:** 3.0 GB
+
+Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
+
+```bash
+docker scout quickview getwilds/popv:latest --platform linux/amd64
+```

--- a/popv/Dockerfile_0.6.1
+++ b/popv/Dockerfile_0.6.1
@@ -4,7 +4,7 @@ FROM python:3.11-slim
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="popv"
-LABEL org.opencontainers.image.description="Container image for PopV (Popular Vote) consensus cell-type annotation in Python"
+LABEL org.opencontainers.image.description="Docker image for PopV in Fred Hutch OCDO's WILDS"
 LABEL org.opencontainers.image.version="0.6.1"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
@@ -24,7 +24,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Install popv and its dependencies via pip
-RUN pip install --no-cache-dir popv==0.6.1
+RUN pip install --no-cache-dir popv==0.6.1 jupyterlab==4.5.6
 
 # Smoke test
 RUN python -c "import popv; print(popv.__version__)"

--- a/popv/Dockerfile_0.6.1
+++ b/popv/Dockerfile_0.6.1
@@ -1,0 +1,30 @@
+
+# Using Python base image
+FROM python:3.11-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="popv"
+LABEL org.opencontainers.image.description="Container image for PopV (Popular Vote) consensus cell-type annotation in Python"
+LABEL org.opencontainers.image.version="0.6.1"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install system dependencies needed for building Python packages
+RUN apt-get update \
+  && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && GPP_VERSION=$(apt-cache policy g++ | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  gcc="${GCC_VERSION}" \
+  g++="${GPP_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install popv and its dependencies via pip
+RUN pip install --no-cache-dir popv==0.6.1
+
+# Smoke test
+RUN python -c "import popv; print(popv.__version__)"

--- a/popv/Dockerfile_0.6.1
+++ b/popv/Dockerfile_0.6.1
@@ -14,6 +14,9 @@ LABEL org.opencontainers.image.licenses=MIT
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Prevent host user site-packages from leaking into the container's Python env
+ENV PYTHONNOUSERSITE=1
+
 # Install system dependencies needed for building Python packages
 RUN apt-get update \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \

--- a/popv/Dockerfile_latest
+++ b/popv/Dockerfile_latest
@@ -4,7 +4,7 @@ FROM python:3.11-slim
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="popv"
-LABEL org.opencontainers.image.description="Container image for PopV (Popular Vote) consensus cell-type annotation in Python"
+LABEL org.opencontainers.image.description="Docker image for PopV in Fred Hutch OCDO's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
@@ -24,7 +24,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Install popv and its dependencies via pip
-RUN pip install --no-cache-dir popv==0.6.1
+RUN pip install --no-cache-dir popv==0.6.1 jupyterlab==4.5.6
 
 # Smoke test
 RUN python -c "import popv; print(popv.__version__)"

--- a/popv/Dockerfile_latest
+++ b/popv/Dockerfile_latest
@@ -14,6 +14,9 @@ LABEL org.opencontainers.image.licenses=MIT
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Prevent host user site-packages from leaking into the container's Python env
+ENV PYTHONNOUSERSITE=1
+
 # Install system dependencies needed for building Python packages
 RUN apt-get update \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \

--- a/popv/Dockerfile_latest
+++ b/popv/Dockerfile_latest
@@ -1,0 +1,30 @@
+
+# Using Python base image
+FROM python:3.11-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="popv"
+LABEL org.opencontainers.image.description="Container image for PopV (Popular Vote) consensus cell-type annotation in Python"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install system dependencies needed for building Python packages
+RUN apt-get update \
+  && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && GPP_VERSION=$(apt-cache policy g++ | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  gcc="${GCC_VERSION}" \
+  g++="${GPP_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install popv and its dependencies via pip
+RUN pip install --no-cache-dir popv==0.6.1
+
+# Smoke test
+RUN python -c "import popv; print(popv.__version__)"

--- a/popv/README.md
+++ b/popv/README.md
@@ -11,8 +11,7 @@ This directory contains Docker images for PopV (Popular Vote), a tool for automa
 
 These Docker images are built from `python:3.11-slim` and include:
 
-- PopV v0.6.1: Consensus cell-type annotation using multiple classification algorithms
-- Bundled classification methods: KNN (with BBKNN, Scanorama, scVI, Harmony integration), SVM, Random Forest, CellTypist, scANVI, and OnClass
+- PopV v0.6.1: Consensus cell-type annotation using multiple classification algorithms and bundled models
 - JupyterLab v4.5.6: Interactive notebook environment for running PopV analyses
 
 The images are designed to be minimal and focused on PopV with its essential dependencies.

--- a/popv/README.md
+++ b/popv/README.md
@@ -13,6 +13,7 @@ These Docker images are built from `python:3.11-slim` and include:
 
 - PopV v0.6.1: Consensus cell-type annotation using multiple classification algorithms
 - Bundled classification methods: KNN (with BBKNN, Scanorama, scVI, Harmony integration), SVM, Random Forest, CellTypist, scANVI, and OnClass
+- JupyterLab v4.5.6: Interactive notebook environment for running PopV analyses
 
 The images are designed to be minimal and focused on PopV with its essential dependencies.
 
@@ -66,6 +67,10 @@ docker run --rm -v /path/to/data:/data getwilds/popv:latest \
 # Start an interactive Python session with PopV available
 docker run --rm -it -v /path/to/data:/data getwilds/popv:latest python
 
+# Launch a JupyterLab notebook server
+docker run --rm -it -p 8888:8888 -v /path/to/data:/data getwilds/popv:latest \
+  jupyter lab --ip=0.0.0.0 --allow-root --no-browser --notebook-dir=/data
+
 # Run a one-liner to verify the installation
 docker run --rm getwilds/popv:latest \
   python -c "import popv; print(popv.__version__)"
@@ -73,6 +78,15 @@ docker run --rm getwilds/popv:latest \
 # Using Apptainer
 apptainer run --bind /path/to/data:/data docker://getwilds/popv:latest \
   python /data/annotate_cells.py
+
+# Launch JupyterLab via Apptainer, then open the URL printed in the terminal
+apptainer run --bind /path/to/data:/data docker://getwilds/popv:latest \
+  jupyter lab --ip=0.0.0.0 --allow-root --no-browser --notebook-dir=/data
+
+# Launch JupyterLab on an HPC cluster (e.g., Fred Hutch)
+export PORT=$(fhfreeport)
+apptainer run --bind /path/to/data:/data docker://getwilds/popv:latest \
+  jupyter lab --ip=$(hostname) --port=$PORT --no-browser --notebook-dir=/data
 ```
 
 ## Dockerfile Structure
@@ -82,7 +96,7 @@ The Dockerfile follows these main steps:
 1. Uses `python:3.11-slim` as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs system build dependencies (gcc, g++) with pinned versions
-4. Installs PopV and all Python dependencies via pip
+4. Installs PopV, JupyterLab, and all Python dependencies via pip
 5. Runs a smoke test to verify the installation
 6. Cleans up apt lists to minimize image size
 

--- a/popv/README.md
+++ b/popv/README.md
@@ -1,0 +1,101 @@
+# PopV
+
+This directory contains Docker images for PopV (Popular Vote), a tool for automated consensus cell-type annotation of single-cell RNA-seq data. PopV runs multiple cell-type classification algorithms and computes agreement between them to predict cell types in a query dataset based on a reference dataset.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/popv/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/popv/CVEs_latest.md) )
+- `0.6.1` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/popv/Dockerfile_0.6.1) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/popv/CVEs_0.6.1.md) )
+
+## Image Details
+
+These Docker images are built from `python:3.11-slim` and include:
+
+- PopV v0.6.1: Consensus cell-type annotation using multiple classification algorithms
+- Bundled classification methods: KNN (with BBKNN, Scanorama, scVI, Harmony integration), SVM, Random Forest, CellTypist, scANVI, and OnClass
+
+The images are designed to be minimal and focused on PopV with its essential dependencies.
+
+## Citation
+
+If you use PopV in your research, please cite the original authors:
+
+```
+Ergen, C. et al. (2023). PopV: Reproducible and automated cell type annotation
+using consensus of classification algorithms. bioRxiv.
+https://doi.org/10.1101/2023.08.18.553912
+```
+
+**Tool homepage:** https://github.com/YosefLab/popV
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/popv:latest
+
+# Or pull a specific version
+docker pull getwilds/popv:0.6.1
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/popv:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/popv:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/popv:0.6.1
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/popv:latest
+```
+
+### Example Commands
+
+```bash
+# Run a Python script that uses PopV for cell-type annotation
+docker run --rm -v /path/to/data:/data getwilds/popv:latest \
+  python /data/annotate_cells.py
+
+# Start an interactive Python session with PopV available
+docker run --rm -it -v /path/to/data:/data getwilds/popv:latest python
+
+# Run a one-liner to verify the installation
+docker run --rm getwilds/popv:latest \
+  python -c "import popv; print(popv.__version__)"
+
+# Using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/popv:latest \
+  python /data/annotate_cells.py
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses `python:3.11-slim` as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs system build dependencies (gcc, g++) with pinned versions
+4. Installs PopV and all Python dependencies via pip
+5. Runs a smoke test to verify the installation
+6. Cleans up apt lists to minimize image size
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/popv), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.
+
+---

--- a/popv/README.md
+++ b/popv/README.md
@@ -84,6 +84,9 @@ apptainer run --bind /path/to/data:/data docker://getwilds/popv:latest \
   jupyter lab --ip=0.0.0.0 --allow-root --no-browser --notebook-dir=/data
 
 # Launch JupyterLab on an HPC cluster (e.g., Fred Hutch)
+# First, grab a compute node rather than running on the head/login node:
+#   grabnode  (see https://sciwiki.fredhutch.org/compdemos/grabnode/)
+# Then, from the compute node:
 export PORT=$(fhfreeport)
 apptainer run --bind /path/to/data:/data docker://getwilds/popv:latest \
   jupyter lab --ip=$(hostname) --port=$PORT --no-browser --notebook-dir=/data


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Add a new Docker image for [PopV](https://github.com/YosefLab/popV) (Popular Vote) v0.6.1, a tool for automated consensus cell-type annotation of single-cell RNA-seq data. PopV runs multiple classification algorithms (KNN, SVM, Random Forest, CellTypist, scANVI, OnClass) and computes agreement between them to predict cell types.

- **Base image:** `python:3.11-slim`
- **Installation method:** `pip install popv==0.6.1 jupyterlab==4.5.6`
- **System dependencies:** gcc, g++ (pinned versions, needed for building Python packages)
- **JupyterLab** included for interactive notebook workflows
- Added `popv` to `amd64_only_tools.txt` (depends on scvi-tools/CUDA packages that lack arm64 wheels)

Requested by Walker Azam in the #question-and-answer channel of FH-Data Slack: https://fhdata.slack.com/archives/CD3HGJHJT/p1775833928601519

## Testing

**How did you test these changes?**
- Ran `make lint IMAGE=popv` — passed (only DL3059 info-level note for separate smoke test RUN)
- Ran `make build_amd64 IMAGE=popv` — both `Dockerfile_latest` and `Dockerfile_0.6.1` built successfully
- Smoke test (`python -c "import popv; print(popv.__version__)"`) passed, printing `0.6.1`

**Did the tests pass?**
Yes. Note: image size is ~9GB due to heavy ML dependencies (torch, tensorflow, scvi-tools), which is expected for this type of tool.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

- Image is AMD64-only due to NVIDIA CUDA and scvi-tools dependencies (consistent with the existing `scvi-tools` image)
- JupyterLab was added to support interactive notebook workflows, a common use case for this tool
- README includes HPC-specific instructions for launching JupyterLab on Fred Hutch's cluster using `grabnode` and `fhfreeport`