### PR TITLE
Adding initial version of gffread WILDS Docker image

### DIFF
--- a/gffread/CVEs_0.12.7.md
+++ b/gffread/CVEs_0.12.7.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/gffread:0.12.7
+
+Report generated on 2026-04-10 23:22:26 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 7 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `ubuntu:24.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 7 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `ubuntu:25.10`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/gffread:0.12.7-amd64  │    0C     0H     2M     7L  
+   digest           │  5381e7bfc888                           │                             
+ Base image         │  ubuntu:24.04                           │    0C     0H     2M     7L  
+ Updated base image │  ubuntu:25.10                           │    0C     0H     0M     0L  
+                    │                                         │                  -2     -7  
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/gffread:0.12.7-amd64
+    View base image update recommendations → docker scout recommendations getwilds/gffread:0.12.7-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/gffread:0.12.7-amd64 --org <organization>
+```
+</details>

--- a/gffread/CVEs_latest.md
+++ b/gffread/CVEs_latest.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/gffread:latest
+
+Report generated on 2026-04-10 23:27:52 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 7 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `ubuntu:24.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 7 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `ubuntu:25.10`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/gffread:latest-amd64  │    0C     0H     2M     7L  
+   digest           │  abcd055e8e08                           │                             
+ Base image         │  ubuntu:24.04                           │    0C     0H     2M     7L  
+ Updated base image │  ubuntu:25.10                           │    0C     0H     0M     0L  
+                    │                                         │                  -2     -7  
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/gffread:latest-amd64
+    View base image update recommendations → docker scout recommendations getwilds/gffread:latest-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/gffread:latest-amd64 --org <organization>
+```
+</details>

--- a/gffread/Dockerfile_0.12.7
+++ b/gffread/Dockerfile_0.12.7
@@ -1,0 +1,35 @@
+
+# Using the Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gffread"
+LABEL org.opencontainers.image.description="Docker image for the use of gffread in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="0.12.7"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install build dependencies, compile gffread, and clean up in a single layer
+RUN apt-get update \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  wget="${WGET_VERSION}" \
+  && wget -q --no-check-certificate https://github.com/gpertea/gffread/releases/download/v0.12.7/gffread-0.12.7.tar.gz \
+  && tar -xzf gffread-0.12.7.tar.gz \
+  && make -C gffread-0.12.7 release \
+  && cp gffread-0.12.7/gffread /usr/local/bin/ \
+  && rm -rf gffread-0.12.7 gffread-0.12.7.tar.gz \
+  && apt-get purge -y build-essential wget \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
+
+# Smoke test to verify gffread works on target architecture
+RUN gffread --version

--- a/gffread/Dockerfile_latest
+++ b/gffread/Dockerfile_latest
@@ -1,0 +1,35 @@
+
+# Using the Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gffread"
+LABEL org.opencontainers.image.description="Docker image for the use of gffread in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install build dependencies, compile gffread, and clean up in a single layer
+RUN apt-get update \
+  && BE_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  build-essential="${BE_VERSION}" \
+  wget="${WGET_VERSION}" \
+  && wget -q --no-check-certificate https://github.com/gpertea/gffread/releases/download/v0.12.7/gffread-0.12.7.tar.gz \
+  && tar -xzf gffread-0.12.7.tar.gz \
+  && make -C gffread-0.12.7 release \
+  && cp gffread-0.12.7/gffread /usr/local/bin/ \
+  && rm -rf gffread-0.12.7 gffread-0.12.7.tar.gz \
+  && apt-get purge -y build-essential wget \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
+
+# Smoke test to verify gffread works on target architecture
+RUN gffread --version

--- a/gffread/README.md
+++ b/gffread/README.md
@@ -1,0 +1,105 @@
+# gffread
+
+This directory contains Docker images for gffread, a GFF/GTF utility for parsing, filtering, and converting genome annotation files (GFF3/GTF formats) and for extracting FASTA sequences from genomic annotations.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/gffread/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/gffread/CVEs_latest.md) )
+- `0.12.7` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/gffread/Dockerfile_0.12.7) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/gffread/CVEs_0.12.7.md) )
+
+## Image Details
+
+These Docker images are built from Ubuntu 24.04 and include:
+
+- gffread v0.12.7: GFF/GTF utility for annotation file manipulation and sequence extraction
+
+The images are designed to be minimal and focused on gffread with no additional dependencies beyond what the tool requires at runtime.
+
+## Citation
+
+If you use gffread in your research, please cite the original authors:
+
+```
+Pertea G, Pertea M. GFF Utilities: GffRead and GffCompare.
+F1000Research 2020, 9:304.
+https://doi.org/10.12688/f1000research.23297.2
+```
+
+**Tool homepage:** https://github.com/gpertea/gffread
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/gffread:latest
+
+# Or pull a specific version
+docker pull getwilds/gffread:0.12.7
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/gffread:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/gffread:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/gffread:0.12.7
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/gffread:latest
+```
+
+### Example Commands
+
+```bash
+# Convert GFF3 to GTF format
+docker run --rm -v /path/to/data:/data getwilds/gffread:latest \
+  gffread /data/annotations.gff3 -T -o /data/annotations.gtf
+
+# Extract transcript sequences using a genome FASTA
+docker run --rm -v /path/to/data:/data getwilds/gffread:latest \
+  gffread /data/annotations.gff3 -g /data/genome.fa -w /data/transcripts.fa
+
+# Extract protein sequences from coding transcripts
+docker run --rm -v /path/to/data:/data getwilds/gffread:latest \
+  gffread /data/annotations.gff3 -g /data/genome.fa -y /data/proteins.fa
+
+# Filter annotations by a specific genomic region
+docker run --rm -v /path/to/data:/data getwilds/gffread:latest \
+  gffread /data/annotations.gff3 -r chr1:1000000-2000000 -o /data/filtered.gff3
+
+# Using Apptainer with a local SIF file
+apptainer run --bind /path/to/data:/data gffread_latest.sif \
+  gffread /data/annotations.gff3 -T -o /data/annotations.gtf
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Ubuntu 24.04 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs build dependencies (build-essential, wget) with pinned versions
+4. Downloads and compiles gffread v0.12.7 from source
+5. Copies the binary to `/usr/local/bin/` and removes build dependencies
+6. Performs cleanup to minimize image size
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/gffread), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.
+
+---


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new WILDS Docker image for **gffread** (v0.12.7), a GFF/GTF utility for parsing, filtering, and converting genome annotation files and extracting FASTA sequences from genomic annotations.

- **Base image:** `ubuntu:24.04`
- **Installation method:** Compiled from source using the official release tarball from GitHub
- **Image size:** Minimal — build dependencies (`build-essential`, `wget`) are purged after compilation in a single layer
- **Architectures:** AMD64 and ARM64

## Testing

**How did you test these changes?**

- Ran `make lint IMAGE=gffread` — passed with no warnings
- Ran `make build IMAGE=gffread` — successfully built for both AMD64 and ARM64
- Smoke test (`gffread --version`) passes during build, confirming v0.12.7

**Did the tests pass?**

Yes, all lint and build steps passed cleanly.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

- Chose source compilation on Ubuntu over conda/miniforge since gffread is a single C++ binary — this produces a significantly smaller image compared to a conda-based approach.
- Build dependencies are installed, used, and purged within a single `RUN` layer to keep the final image minimal.
- This image is inspired by the existing Biocontainers image (`quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4`) but rebuilt following WILDS conventions.