### PR TITLE
Switching Sprocket to pre-built binaries in `ollama` image

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -10,7 +10,6 @@ flax
 hisat2
 manta
 megahit
-ollama
 popv
 python-dl
 rmats-turbo

--- a/ollama/Dockerfile_0.21.0
+++ b/ollama/Dockerfile_0.21.0
@@ -16,29 +16,25 @@ RUN apt-get update \
   && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
   && CURL_VERSION=$(apt-cache policy curl | grep Candidate | awk '{print $2}') \
   && CA_CERTIFICATES_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
-  && BUILD_ESSENTIAL_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
-  && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
-  && LIBSSL_DEV_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
     python3="${PYTHON3_VERSION}" \
     python3-pip="${PYTHON3_PIP_VERSION}" \
     curl="${CURL_VERSION}" \
     ca-certificates="${CA_CERTIFICATES_VERSION}" \
-    build-essential="${BUILD_ESSENTIAL_VERSION}" \
-    pkg-config="${PKG_CONFIG_VERSION}" \
-    libssl-dev="${LIBSSL_DEV_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages \
   ollama==0.6.1
 
+ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-  && export PATH="/root/.cargo/bin:$PATH" \
-  && cargo install --version "${SPROCKET_VERSION}" sprocket \
-  && cp /root/.cargo/bin/sprocket /usr/local/bin/sprocket \
-  && rustup self uninstall -y \
-  && rm -rf /root/.cargo
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      ARCH="aarch64-unknown-linux-gnu"; \
+    else \
+      ARCH="x86_64-unknown-linux-gnu"; \
+    fi \
+  && curl -fsSL "https://github.com/stjude-rust-labs/sprocket/releases/download/v${SPROCKET_VERSION}/sprocket-v${SPROCKET_VERSION}-${ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin sprocket
 
 RUN ollama --version && python3 -c "import ollama" && sprocket --version
 

--- a/ollama/Dockerfile_latest
+++ b/ollama/Dockerfile_latest
@@ -16,29 +16,25 @@ RUN apt-get update \
   && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
   && CURL_VERSION=$(apt-cache policy curl | grep Candidate | awk '{print $2}') \
   && CA_CERTIFICATES_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
-  && BUILD_ESSENTIAL_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
-  && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
-  && LIBSSL_DEV_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
     python3="${PYTHON3_VERSION}" \
     python3-pip="${PYTHON3_PIP_VERSION}" \
     curl="${CURL_VERSION}" \
     ca-certificates="${CA_CERTIFICATES_VERSION}" \
-    build-essential="${BUILD_ESSENTIAL_VERSION}" \
-    pkg-config="${PKG_CONFIG_VERSION}" \
-    libssl-dev="${LIBSSL_DEV_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages \
   ollama==0.6.1
 
+ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-  && export PATH="/root/.cargo/bin:$PATH" \
-  && cargo install --version "${SPROCKET_VERSION}" sprocket \
-  && cp /root/.cargo/bin/sprocket /usr/local/bin/sprocket \
-  && rustup self uninstall -y \
-  && rm -rf /root/.cargo
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      ARCH="aarch64-unknown-linux-gnu"; \
+    else \
+      ARCH="x86_64-unknown-linux-gnu"; \
+    fi \
+  && curl -fsSL "https://github.com/stjude-rust-labs/sprocket/releases/download/v${SPROCKET_VERSION}/sprocket-v${SPROCKET_VERSION}-${ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin sprocket
 
 RUN ollama --version && python3 -c "import ollama" && sprocket --version
 

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -12,17 +12,15 @@ This directory contains Docker images for [Ollama](https://ollama.com/), an LLM 
 These Docker images are built from `ollama/ollama:0.21.0` and include:
 
 - Ollama v0.21.0: LLM inference server for running models locally
-- Sprocket v0.23.0: WDL script validator (compiled from source via cargo)
+- Sprocket v0.23.0: WDL script validator
 - Python ollama SDK v0.6.1: Python client library for interacting with Ollama
 - Python 3 (system version from base image)
 
-Note: Sprocket is compiled from source during the Docker build using Rust's `cargo install`. The Rust toolchain is removed after compilation to minimize image size.
+Sprocket is installed from prebuilt binaries published on the [Sprocket GitHub releases page](https://github.com/stjude-rust-labs/sprocket/releases).
 
 ## Platform Availability
 
-Available for: linux/amd64 only
-
-Sprocket is compiled from source during the Docker build, which causes arm64 builds to exceed CI timeout limits.
+Available for: linux/amd64, linux/arm64
 
 A GPU is not required to run this image, but is highly encouraged — CPU-only execution of LLMs is significantly slower.
 
@@ -97,7 +95,7 @@ The Dockerfile follows these main steps:
 2. Adds metadata labels for documentation and attribution
 3. Installs system dependencies with pinned versions (Python, curl, build tools)
 4. Installs the Python ollama SDK via pip
-5. Installs Rust via rustup, compiles Sprocket from source, then removes the Rust toolchain
+5. Downloads the prebuilt Sprocket binary for the target architecture
 6. Runs smoke tests to verify all tools are installed correctly
 
 ## Security Scanning and CVEs


### PR DESCRIPTION
## Type of Change

- Bug fix

## Description

Switch Sprocket installation in the Ollama Docker image from `cargo install` (compile from source) to prebuilt binaries from GitHub releases. This fixes the [CI build failure](https://github.com/getwilds/wilds-docker-library/actions/runs/24900525014) caused by Sprocket v0.23.0's dependencies.

Additional changes:
- Removed build-only dependencies (`build-essential`, `pkg-config`, `libssl-dev`) that were only needed for Rust compilation
- Removed `ollama` from `amd64_only_tools.txt` to enable arm64 builds (the build from source timeout was the only reason it was amd64-only)
- Uses `TARGETARCH` to download the correct prebuilt binary for each platform
- Updated README to reflect the new installation method and multi-platform support

## Testing

**How did you test these changes?**

Ran `make build IMAGE=ollama` locally.

**Did the tests pass?**

Yes — smoke test verifies `ollama --version`, `python3 -c "import ollama"`, and `sprocket --version`.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

- The `ollama/ollama:0.21.0` base image uses Ubuntu 24.04 (glibc 2.39), which is compatible with Sprocket's prebuilt binaries (v0.10+ require glibc 2.38+). The previous `cargo install` approach was originally needed for the older 0.5.4 base image (Ubuntu 22.04 / glibc 2.35), which has since been removed.
- Prebuilt binaries are available for both amd64 and arm64, so this also enables multi-platform builds without the 6-hour CI timeout that Rust compilation caused on arm64.
- The image will be smaller without the Rust build dependencies, and builds will be significantly faster.