### PR TITLE
Adding initial draft of python-utils WILDS Docker image

### DIFF
--- a/python-utils/CVEs_0.1.0.md
+++ b/python-utils/CVEs_0.1.0.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/python-utils:0.1.0
+
+Report generated on 2026-04-24 20:32:51 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 3 |
+| 🟢 Low | 23 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `python:3.12-slim`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 3 |
+| 🟢 Low | 23 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.13-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/python-utils:0.1.0-amd64  │    0C     0H     3M    23L  
+   digest           │  8ae58363bc0d                               │                             
+ Base image         │  python:3.12-slim                           │    0C     0H     3M    23L  
+ Updated base image │  python:3.13-slim                           │    0C     0H     2M    22L  
+                    │                                             │                  -1     -1  
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/python-utils:0.1.0-amd64
+    View base image update recommendations → docker scout recommendations getwilds/python-utils:0.1.0-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/python-utils:0.1.0-amd64 --org <organization>
+```
+</details>

--- a/python-utils/CVEs_0.1.0.md
+++ b/python-utils/CVEs_0.1.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/python-utils:0.1.0
 
-Report generated on 2026-04-24 20:55:11 PST
+Report generated on 2026-04-24 22:29:46 PST
 
 ## Platform Coverage
 
@@ -36,7 +36,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 ```text
 Target             │  getwilds/python-utils:0.1.0-amd64  │    0C     1H     3M    39L  
-   digest           │  670dfd1cd24b                               │                             
+   digest           │  4b0b46e54e29                               │                             
  Base image         │  python:3.12-slim                           │    0C     0H     3M    23L  
  Updated base image │  python:3.13-slim                           │    0C     0H     2M    22L  
                     │                                             │                  -1     -1  

--- a/python-utils/CVEs_0.1.0.md
+++ b/python-utils/CVEs_0.1.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/python-utils:0.1.0
 
-Report generated on 2026-04-24 20:32:51 PST
+Report generated on 2026-04-24 20:55:11 PST
 
 ## Platform Coverage
 
@@ -11,9 +11,9 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 | Severity | Count |
 |----------|-------|
 | 🔴 Critical | 0 |
-| 🟠 High | 0 |
+| 🟠 High | 1 |
 | 🟡 Medium | 3 |
-| 🟢 Low | 23 |
+| 🟢 Low | 39 |
 | ⚪ Unknown | 0 |
 
 ## 🐳 Base Image
@@ -35,8 +35,8 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target             │  getwilds/python-utils:0.1.0-amd64  │    0C     0H     3M    23L  
-   digest           │  8ae58363bc0d                               │                             
+Target             │  getwilds/python-utils:0.1.0-amd64  │    0C     1H     3M    39L  
+   digest           │  670dfd1cd24b                               │                             
  Base image         │  python:3.12-slim                           │    0C     0H     3M    23L  
  Updated base image │  python:3.13-slim                           │    0C     0H     2M    22L  
                     │                                             │                  -1     -1  

--- a/python-utils/CVEs_latest.md
+++ b/python-utils/CVEs_latest.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/python-utils:latest
+
+Report generated on 2026-04-24 20:39:52 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 3 |
+| 🟢 Low | 23 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `python:3.12-slim`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 3 |
+| 🟢 Low | 23 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.13-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/python-utils:latest-amd64  │    0C     0H     3M    23L  
+   digest           │  7cd9372ef632                                │                             
+ Base image         │  python:3.12-slim                            │    0C     0H     3M    23L  
+ Updated base image │  python:3.13-slim                            │    0C     0H     2M    22L  
+                    │                                              │                  -1     -1  
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/python-utils:latest-amd64
+    View base image update recommendations → docker scout recommendations getwilds/python-utils:latest-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/python-utils:latest-amd64 --org <organization>
+```
+</details>

--- a/python-utils/CVEs_latest.md
+++ b/python-utils/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/python-utils:latest
 
-Report generated on 2026-04-24 21:03:26 PST
+Report generated on 2026-04-24 22:38:17 PST
 
 ## Platform Coverage
 
@@ -36,7 +36,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 ```text
 Target             │  getwilds/python-utils:latest-amd64  │    0C     1H     3M    39L  
-   digest           │  464e24382564                                │                             
+   digest           │  3ebdf9d25975                                │                             
  Base image         │  python:3.12-slim                            │    0C     0H     3M    23L  
  Updated base image │  python:3.13-slim                            │    0C     0H     2M    22L  
                     │                                              │                  -1     -1  

--- a/python-utils/CVEs_latest.md
+++ b/python-utils/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/python-utils:latest
 
-Report generated on 2026-04-24 20:39:52 PST
+Report generated on 2026-04-24 21:03:26 PST
 
 ## Platform Coverage
 
@@ -11,9 +11,9 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 | Severity | Count |
 |----------|-------|
 | 🔴 Critical | 0 |
-| 🟠 High | 0 |
+| 🟠 High | 1 |
 | 🟡 Medium | 3 |
-| 🟢 Low | 23 |
+| 🟢 Low | 39 |
 | ⚪ Unknown | 0 |
 
 ## 🐳 Base Image
@@ -35,8 +35,8 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target             │  getwilds/python-utils:latest-amd64  │    0C     0H     3M    23L  
-   digest           │  7cd9372ef632                                │                             
+Target             │  getwilds/python-utils:latest-amd64  │    0C     1H     3M    39L  
+   digest           │  464e24382564                                │                             
  Base image         │  python:3.12-slim                            │    0C     0H     3M    23L  
  Updated base image │  python:3.13-slim                            │    0C     0H     2M    22L  
                     │                                              │                  -1     -1  

--- a/python-utils/Dockerfile_0.1.0
+++ b/python-utils/Dockerfile_0.1.0
@@ -15,6 +15,13 @@ LABEL org.opencontainers.image.licenses=MIT
 # Set the shell option to fail if any command in a pipe fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Installing git (needed by downstream WDL workflows that clone repos at runtime)
+RUN apt-get update \
+    && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+    && apt-get install -y --no-install-recommends \
+        git="${GIT_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
 # Installing core scientific and bioinformatics Python packages with pinned versions
 RUN pip install --no-cache-dir \
     pysam==0.23.3 \

--- a/python-utils/Dockerfile_0.1.0
+++ b/python-utils/Dockerfile_0.1.0
@@ -15,11 +15,13 @@ LABEL org.opencontainers.image.licenses=MIT
 # Set the shell option to fail if any command in a pipe fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Installing git (needed by downstream WDL workflows that clone repos at runtime)
+# Installing git and curl (needed by downstream WDL workflows that clone repos and fetch files at runtime)
 RUN apt-get update \
     && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+    && CURL_VERSION=$(apt-cache policy curl | grep Candidate | awk '{print $2}') \
     && apt-get install -y --no-install-recommends \
         git="${GIT_VERSION}" \
+        curl="${CURL_VERSION}" \
     && rm -rf /var/lib/apt/lists/*
 
 # Installing core scientific and bioinformatics Python packages with pinned versions

--- a/python-utils/Dockerfile_0.1.0
+++ b/python-utils/Dockerfile_0.1.0
@@ -1,0 +1,37 @@
+
+# Using Python slim base image for a lean footprint
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="python-utils"
+LABEL org.opencontainers.image.description="Docker image for general-purpose Python utilities in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="0.1.0"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing core scientific and bioinformatics Python packages with pinned versions
+RUN pip install --no-cache-dir \
+    pysam==0.23.3 \
+    numpy==2.4.4 \
+    scipy==1.17.1 \
+    pandas==3.0.2 \
+    matplotlib==3.10.9 \
+    seaborn==0.13.2
+
+# Set working directory for data analysis
+WORKDIR /data
+
+# Smoke test: verify each package imports and report versions
+RUN python -c "import pysam, numpy, scipy, pandas, matplotlib, seaborn; \
+    print('pysam', pysam.__version__); \
+    print('numpy', numpy.__version__); \
+    print('scipy', scipy.__version__); \
+    print('pandas', pandas.__version__); \
+    print('matplotlib', matplotlib.__version__); \
+    print('seaborn', seaborn.__version__)"

--- a/python-utils/Dockerfile_latest
+++ b/python-utils/Dockerfile_latest
@@ -15,6 +15,13 @@ LABEL org.opencontainers.image.licenses=MIT
 # Set the shell option to fail if any command in a pipe fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Installing git (needed by downstream WDL workflows that clone repos at runtime)
+RUN apt-get update \
+    && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+    && apt-get install -y --no-install-recommends \
+        git="${GIT_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
 # Installing core scientific and bioinformatics Python packages with pinned versions
 RUN pip install --no-cache-dir \
     pysam==0.23.3 \

--- a/python-utils/Dockerfile_latest
+++ b/python-utils/Dockerfile_latest
@@ -1,0 +1,37 @@
+
+# Using Python slim base image for a lean footprint
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="python-utils"
+LABEL org.opencontainers.image.description="Docker image for general-purpose Python utilities in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing core scientific and bioinformatics Python packages with pinned versions
+RUN pip install --no-cache-dir \
+    pysam==0.23.3 \
+    numpy==2.4.4 \
+    scipy==1.17.1 \
+    pandas==3.0.2 \
+    matplotlib==3.10.9 \
+    seaborn==0.13.2
+
+# Set working directory for data analysis
+WORKDIR /data
+
+# Smoke test: verify each package imports and report versions
+RUN python -c "import pysam, numpy, scipy, pandas, matplotlib, seaborn; \
+    print('pysam', pysam.__version__); \
+    print('numpy', numpy.__version__); \
+    print('scipy', scipy.__version__); \
+    print('pandas', pandas.__version__); \
+    print('matplotlib', matplotlib.__version__); \
+    print('seaborn', seaborn.__version__)"

--- a/python-utils/Dockerfile_latest
+++ b/python-utils/Dockerfile_latest
@@ -15,11 +15,13 @@ LABEL org.opencontainers.image.licenses=MIT
 # Set the shell option to fail if any command in a pipe fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Installing git (needed by downstream WDL workflows that clone repos at runtime)
+# Installing git and curl (needed by downstream WDL workflows that clone repos and fetch files at runtime)
 RUN apt-get update \
     && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
+    && CURL_VERSION=$(apt-cache policy curl | grep Candidate | awk '{print $2}') \
     && apt-get install -y --no-install-recommends \
         git="${GIT_VERSION}" \
+        curl="${CURL_VERSION}" \
     && rm -rf /var/lib/apt/lists/*
 
 # Installing core scientific and bioinformatics Python packages with pinned versions

--- a/python-utils/README.md
+++ b/python-utils/README.md
@@ -1,0 +1,102 @@
+# python-utils
+
+This directory contains Docker images for python-utils, a lean general-purpose Python environment that bundles a handful of ubiquitous scientific computing and bioinformatics packages on top of a slim Python base.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/python-utils/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/python-utils/CVEs_latest.md) )
+- `0.1.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/python-utils/Dockerfile_0.1.0) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/python-utils/CVEs_0.1.0.md) )
+
+## Image Details
+
+These Docker images are built from the `python:3.12-slim` base image and include:
+
+- pysam 0.23.3: Python interface to htslib for reading/writing SAM/BAM/VCF/BCF files
+- numpy 2.4.4: Core N-dimensional array library for numerical computing
+- scipy 1.17.1: Scientific computing library (optimization, stats, signal processing, etc.)
+- pandas 3.0.2: Data frames and tabular data analysis
+- matplotlib 3.10.9: Plotting and visualization library
+- seaborn 0.13.2: Statistical data visualization built on matplotlib
+
+The images are designed to be a lean, general-purpose Python environment for WILDS WDL modules and analyses that need common scientific/bioinformatics packages without the heavy footprint of deep learning frameworks. For GPU-accelerated deep learning workflows, see the `python-dl` image instead.
+
+## Citation
+
+This image simply bundles several widely used open-source Python packages. If you use them in your research, please cite the original authors:
+
+- **pysam**: https://github.com/pysam-developers/pysam (wraps htslib — Bonfield et al., *GigaScience* 2021, https://doi.org/10.1093/gigascience/giab007)
+- **NumPy**: Harris, C.R., et al. (2020). Array programming with NumPy. *Nature* 585, 357–362. https://doi.org/10.1038/s41586-020-2649-2
+- **SciPy**: Virtanen, P., et al. (2020). SciPy 1.0: fundamental algorithms for scientific computing in Python. *Nature Methods* 17, 261–272. https://doi.org/10.1038/s41592-019-0686-2
+- **pandas**: McKinney, W. (2010). Data Structures for Statistical Computing in Python. *Proc. 9th Python in Science Conference*. https://doi.org/10.25080/Majora-92bf1922-00a
+- **Matplotlib**: Hunter, J. D. (2007). Matplotlib: A 2D Graphics Environment. *Computing in Science & Engineering* 9(3), 90–95. https://doi.org/10.1109/MCSE.2007.55
+- **seaborn**: Waskom, M. L. (2021). seaborn: statistical data visualization. *Journal of Open Source Software* 6(60), 3021. https://doi.org/10.21105/joss.03021
+
+## Usage
+
+### Docker
+
+```bash
+docker pull getwilds/python-utils:latest
+# or
+docker pull getwilds/python-utils:0.1.0
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/python-utils:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+apptainer pull docker://getwilds/python-utils:latest
+# or
+apptainer pull docker://getwilds/python-utils:0.1.0
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/python-utils:latest
+```
+
+### Example Commands
+
+```bash
+# Run a Python analysis script with Docker
+docker run --rm -v /path/to/data:/data getwilds/python-utils:latest \
+  python /data/analysis.py --input /data/input.csv --output /data/results.csv
+
+# Drop into an interactive Python shell
+docker run --rm -it -v /path/to/data:/data getwilds/python-utils:latest python
+
+# Inspect a BAM file with pysam
+docker run --rm -v /path/to/data:/data getwilds/python-utils:latest \
+  python -c "import pysam; bam = pysam.AlignmentFile('/data/sample.bam', 'rb'); print(bam.header)"
+
+# Run a Python script with Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/python-utils:latest \
+  python /data/analysis.py --input /data/input.csv --output /data/results.csv
+
+# ... or a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data python-utils_latest.sif \
+  python /data/analysis.py --input /data/input.csv --output /data/results.csv
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses `python:3.12-slim` as the base image for a minimal Python environment
+2. Adds metadata labels for documentation and attribution
+3. Sets the shell pipefail option for safer pipelines
+4. Installs the scientific/bioinformatics Python packages via pip with pinned versions and `--no-cache-dir`
+5. Sets `/data` as the working directory for analysis
+6. Runs a smoke test that imports each package and prints its version
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/tree/main/python-utils), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.

--- a/python-utils/README.md
+++ b/python-utils/README.md
@@ -12,6 +12,7 @@ This directory contains Docker images for python-utils, a lean general-purpose P
 These Docker images are built from the `python:3.12-slim` base image and include:
 
 - git: version control client, included to support WDL workflows that clone repositories at runtime
+- curl: command-line HTTP client, included to support WDL workflows that fetch files at runtime
 - pysam 0.23.3: Python interface to htslib for reading/writing SAM/BAM/VCF/BCF files
 - numpy 2.4.4: Core N-dimensional array library for numerical computing
 - scipy 1.17.1: Scientific computing library (optimization, stats, signal processing, etc.)
@@ -86,7 +87,7 @@ The Dockerfile follows these main steps:
 1. Uses `python:3.12-slim` as the base image for a minimal Python environment
 2. Adds metadata labels for documentation and attribution
 3. Sets the shell pipefail option for safer pipelines
-4. Installs git via apt with the candidate version captured from `apt-cache policy`, then cleans up `/var/lib/apt/lists`
+4. Installs git and curl via apt with candidate versions captured from `apt-cache policy`, then cleans up `/var/lib/apt/lists`
 5. Installs the scientific/bioinformatics Python packages via pip with pinned versions and `--no-cache-dir`
 6. Sets `/data` as the working directory for analysis
 7. Runs a smoke test that imports each package and prints its version

--- a/python-utils/README.md
+++ b/python-utils/README.md
@@ -11,6 +11,7 @@ This directory contains Docker images for python-utils, a lean general-purpose P
 
 These Docker images are built from the `python:3.12-slim` base image and include:
 
+- git: version control client, included to support WDL workflows that clone repositories at runtime
 - pysam 0.23.3: Python interface to htslib for reading/writing SAM/BAM/VCF/BCF files
 - numpy 2.4.4: Core N-dimensional array library for numerical computing
 - scipy 1.17.1: Scientific computing library (optimization, stats, signal processing, etc.)
@@ -85,9 +86,10 @@ The Dockerfile follows these main steps:
 1. Uses `python:3.12-slim` as the base image for a minimal Python environment
 2. Adds metadata labels for documentation and attribution
 3. Sets the shell pipefail option for safer pipelines
-4. Installs the scientific/bioinformatics Python packages via pip with pinned versions and `--no-cache-dir`
-5. Sets `/data` as the working directory for analysis
-6. Runs a smoke test that imports each package and prints its version
+4. Installs git via apt with the candidate version captured from `apt-cache policy`, then cleans up `/var/lib/apt/lists`
+5. Installs the scientific/bioinformatics Python packages via pip with pinned versions and `--no-cache-dir`
+6. Sets `/data` as the working directory for analysis
+7. Runs a smoke test that imports each package and prints its version
 
 ## Security Scanning and CVEs
 


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new `python-utils` Docker image — a lean, general-purpose Python 3.12 environment bundling common scientific computing and bioinformatics packages, plus a couple of system utilities, for use in WILDS WDL modules.

Built from `python:3.12-slim`. Installs:

- `git` and `curl` via apt (candidate versions captured from `apt-cache policy` at build time, following the pattern used in `gdc-client`) — included so downstream WDL tasks can clone repos and fetch files at runtime
- Pinned scientific Python packages via pip:
  - pysam 0.23.3
  - numpy 2.4.4
  - scipy 1.17.1
  - pandas 3.0.2
  - matplotlib 3.10.9
  - seaborn 0.13.2

Intended as a lightweight companion to the heavier `python-dl` image for workflows that need common scientific/bioinformatics packages without GPU/deep-learning dependencies.

## Testing

**How did you test these changes?**
Local `make lint IMAGE=python-utils` and `make build_amd64 IMAGE=python-utils`. The Dockerfile includes a smoke test that imports each bundled Python package and prints its version as the final build step, so a successful build confirms all packages load.

**Did the tests pass?**
Yes — hadolint clean and the image builds with the smoke test passing.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

- Python package selection is intentionally minimal — this is meant to be a broadly useful base for quick analyses, not a one-stop shop. If a workflow needs scikit-learn, statsmodels, etc., those can be layered on top or justify a separate image.
- `git` and `curl` were added specifically to unblock a downstream WDL workflow; they're cheap inclusions but do widen the image's CVE surface area slightly versus a pure-Python install — flagging in case reviewers prefer to keep the base trimmer and push these into a derived image.