### PR TITLE
Adding OpenCode to Ollama WILDS Docker image

### DIFF
--- a/ollama/CVEs_0.21.0.md
+++ b/ollama/CVEs_0.21.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:0.21.0
 
-Report generated on 2026-04-24 17:24:16 PST
+Report generated on 2026-05-06 23:35:16 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 3.5 GB
+**Image size:** 3.6 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/ollama/CVEs_latest.md
+++ b/ollama/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:latest
 
-Report generated on 2026-04-24 17:30:36 PST
+Report generated on 2026-05-06 23:41:55 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 3.5 GB
+**Image size:** 3.6 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/ollama/Dockerfile_0.21.0
+++ b/ollama/Dockerfile_0.21.0
@@ -1,7 +1,7 @@
 FROM ollama/ollama:0.21.0
 
 LABEL org.opencontainers.image.title="ollama"
-LABEL org.opencontainers.image.description="Docker image for Ollama in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.description="Docker image for Ollama in Fred Hutch OCDO's WILDS, with OpenCode for LLM-driven coding workflows"
 LABEL org.opencontainers.image.version="0.21.0"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
@@ -36,7 +36,18 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
   && curl -fsSL "https://github.com/stjude-rust-labs/sprocket/releases/download/v${SPROCKET_VERSION}/sprocket-v${SPROCKET_VERSION}-${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin sprocket
 
-RUN ollama --version && python3 -c "import ollama" && sprocket --version
+ARG OPENCODE_VERSION=1.14.39
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      ARCH="arm64"; \
+    else \
+      ARCH="x64"; \
+    fi \
+  && curl -fsSL -o /tmp/opencode.tar.gz \
+    "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ARCH}.tar.gz" \
+  && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin opencode \
+  && rm /tmp/opencode.tar.gz
+
+RUN ollama --version && python3 -c "import ollama" && sprocket --version && opencode --version
 
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/ollama/Dockerfile_latest
+++ b/ollama/Dockerfile_latest
@@ -1,7 +1,7 @@
 FROM ollama/ollama:0.21.0
 
 LABEL org.opencontainers.image.title="ollama"
-LABEL org.opencontainers.image.description="Docker image for Ollama in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.description="Docker image for Ollama in Fred Hutch OCDO's WILDS, with OpenCode for LLM-driven coding workflows"
 LABEL org.opencontainers.image.version="0.21.0"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
@@ -36,7 +36,18 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
   && curl -fsSL "https://github.com/stjude-rust-labs/sprocket/releases/download/v${SPROCKET_VERSION}/sprocket-v${SPROCKET_VERSION}-${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin sprocket
 
-RUN ollama --version && python3 -c "import ollama" && sprocket --version
+ARG OPENCODE_VERSION=1.14.39
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      ARCH="arm64"; \
+    else \
+      ARCH="x64"; \
+    fi \
+  && curl -fsSL -o /tmp/opencode.tar.gz \
+    "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ARCH}.tar.gz" \
+  && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin opencode \
+  && rm /tmp/opencode.tar.gz
+
+RUN ollama --version && python3 -c "import ollama" && sprocket --version && opencode --version
 
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -1,6 +1,6 @@
 # Ollama
 
-This directory contains Docker images for [Ollama](https://ollama.com/), an LLM inference server, bundled with the [Sprocket](https://github.com/stjude-rust-labs/sprocket) WDL validator and the [Python ollama SDK](https://pypi.org/project/ollama/). Designed for benchmarking LLM-generated WDL scripts.
+This directory contains Docker images for [Ollama](https://ollama.com/), an LLM inference server, bundled with the [Sprocket](https://github.com/stjude-rust-labs/sprocket) WDL validator, the [Python ollama SDK](https://pypi.org/project/ollama/), and [OpenCode](https://github.com/sst/opencode), an open-source AI coding agent. Designed for benchmarking LLM-generated WDL scripts.
 
 ## Available Versions
 
@@ -13,10 +13,11 @@ These Docker images are built from `ollama/ollama:0.21.0` and include:
 
 - Ollama v0.21.0: LLM inference server for running models locally
 - Sprocket v0.23.0: WDL script validator
+- OpenCode v1.14.39: open-source AI coding agent
 - Python ollama SDK v0.6.1: Python client library for interacting with Ollama
 - Python 3 (system version from base image)
 
-Sprocket is installed from prebuilt binaries published on the [Sprocket GitHub releases page](https://github.com/stjude-rust-labs/sprocket/releases).
+Sprocket is installed from prebuilt binaries published on the [Sprocket GitHub releases page](https://github.com/stjude-rust-labs/sprocket/releases). OpenCode is installed from prebuilt binaries published on the [OpenCode GitHub releases page](https://github.com/sst/opencode/releases).
 
 ## Platform Availability
 
@@ -26,10 +27,11 @@ A GPU is not required to run this image, but is highly encouraged — CPU-only e
 
 ## Citation
 
-This image bundles two independent tools. If you use them in your research, please cite the original authors:
+This image bundles three independent tools. If you use them in your research, please cite the original authors:
 
 - **Ollama** (LLM inference server): https://ollama.com/
 - **Sprocket** (WDL execution engine): https://github.com/stjude-rust-labs/sprocket
+- **OpenCode** (AI coding agent): https://github.com/sst/opencode
 
 ## Usage
 
@@ -65,6 +67,7 @@ apptainer pull docker://ghcr.io/getwilds/ollama:latest
 # Check installed versions
 docker run --rm getwilds/ollama:latest ollama --version
 docker run --rm getwilds/ollama:latest sprocket --version
+docker run --rm getwilds/ollama:latest opencode --version
 
 # Start the container with GPU access
 docker run --rm --gpus all -it getwilds/ollama:latest
@@ -96,7 +99,8 @@ The Dockerfile follows these main steps:
 3. Installs system dependencies with pinned versions (Python, curl, build tools)
 4. Installs the Python ollama SDK via pip
 5. Downloads the prebuilt Sprocket binary for the target architecture
-6. Runs smoke tests to verify all tools are installed correctly
+6. Downloads the prebuilt OpenCode binary for the target architecture
+7. Runs smoke tests to verify all tools are installed correctly
 
 ## Security Scanning and CVEs
 


### PR DESCRIPTION
## Type of Change

- Version update (adds OpenCode tooling to existing Ollama image)
- Documentation update

## Description

Adds [OpenCode](https://github.com/sst/opencode) v1.14.39, an open-source AI coding agent, to both the `latest` and `0.21.0` Ollama images. OpenCode ships as a standalone binary (Bun runtime embedded), so the install is a pinned multi-arch tarball download from the GitHub releases page — same pattern already used for Sprocket. The smoke test, image description label, and README components/citation/usage sections were updated to reflect the new tool.

Motivation: enables LLM-driven coding workflows on the HPC system using the Ollama-served models already in this image.

## Testing

**How did you test these changes?**
Ran `make lint IMAGE=ollama` locally — both Dockerfiles pass hadolint. Full multi-arch build will be exercised via the manual GitHub Actions trigger.

**Did the tests pass?**
Lint passed. Build verification deferred to CI: https://github.com/getwilds/wilds-docker-library/actions/runs/25466868900/job/74722014829

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with CI/CD
- [x] Image builds successfully for target platform(s)

## Additional Context

- OpenCode is pinned at v1.14.39 (latest stable as of 2026-05-06).
- The image description label was lightly extended ("…with OpenCode for LLM-driven coding workflows"); image title remains `ollama`.