### PR TITLE
Addition of Seurat docker image

### DIFF
--- a/seurat/Dockerfile_5.2.1
+++ b/seurat/Dockerfile_5.2.1
@@ -1,0 +1,41 @@
+# Use Bioconductor base image
+FROM bioconductor/bioconductor_docker:RELEASE_3_21
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="seurat"
+LABEL org.opencontainers.image.description="Docker image for Seurat single-cell RNA-seq analysis in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="5.2.1"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install system dependencies
+RUN apt-get update \
+  && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
+  && LIBFFTW3_VERSION=$(apt-cache policy libfftw3-dev | grep Candidate | awk '{print $2}') \
+  && LIBGSL_VERSION=$(apt-cache policy libgsl-dev | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  libhdf5-dev="${LIBHDF5_VERSION}" \
+  libfftw3-dev="${LIBFFTW3_VERSION}" \
+  libgsl-dev="${LIBGSL_VERSION}" \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install required R packages
+RUN R -e "BiocManager::install(c('Seurat', 'ggplot2', 'dplyr', 'patchwork', 'optparse', 'glmGamPoi'), update=FALSE, ask=FALSE, dependencies=TRUE)"
+
+# Copy the Seurat analysis script to the container
+COPY seurat/seurat_analysis.R /usr/local/bin/seurat_analysis.R
+RUN chmod +x /usr/local/bin/seurat_analysis.R
+
+# Set working directory
+WORKDIR /data

--- a/seurat/Dockerfile_latest
+++ b/seurat/Dockerfile_latest
@@ -1,0 +1,42 @@
+
+# Use Bioconductor base image
+FROM bioconductor/bioconductor_docker:RELEASE_3_21
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="seurat"
+LABEL org.opencontainers.image.description="Docker image for Seurat single-cell RNA-seq analysis in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install system dependencies
+RUN apt-get update \
+  && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
+  && LIBFFTW3_VERSION=$(apt-cache policy libfftw3-dev | grep Candidate | awk '{print $2}') \
+  && LIBGSL_VERSION=$(apt-cache policy libgsl-dev | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  libhdf5-dev="${LIBHDF5_VERSION}" \
+  libfftw3-dev="${LIBFFTW3_VERSION}" \
+  libgsl-dev="${LIBGSL_VERSION}" \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install required R packages
+RUN R -e "BiocManager::install(c('Seurat', 'ggplot2', 'dplyr', 'patchwork', 'optparse', 'glmGamPoi'), update=FALSE, ask=FALSE, dependencies=TRUE)"
+
+# Copy the Seurat analysis script to the container
+COPY seurat/seurat_analysis.R /usr/local/bin/seurat_analysis.R
+RUN chmod +x /usr/local/bin/seurat_analysis.R
+
+# Set working directory
+WORKDIR /data

--- a/seurat/README.md
+++ b/seurat/README.md
@@ -1,0 +1,133 @@
+# Seurat
+
+This directory contains Docker images for Seurat, an R package for single-cell RNA-seq data analysis.
+
+## Available Versions
+
+- `latest`: The most up-to-date stable version (currently Seurat v5.2.1 from Bioconductor 3.21)
+- `5.2.1`: Seurat v5.2.1 from Bioconductor 3.21
+
+## Image Details
+
+These Docker images are built from the Bioconductor base image and include:
+
+- Seurat v5.2.1: A package for single-cell RNA-seq data quality control, analysis, and exploration
+- glmGamPoi: For fast negative binomial regression in SCTransform normalization
+- ggplot2 & patchwork: For visualization and plot composition
+- dplyr: For data manipulation
+- optparse: For command-line interface
+- A script that performs standard gene expression scRNA-seq processing (see below)
+
+## Usage
+
+### Docker
+
+```bash
+docker pull getwilds/seurat:latest
+# or
+docker pull getwilds/seurat:5.2.1
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/seurat:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+apptainer pull docker://getwilds/seurat:latest
+# or
+apptainer pull docker://getwilds/seurat:5.2.1
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/seurat:latest
+```
+
+### Example Commands
+
+#### Running Seurat Analysis
+
+```bash
+# Running Seurat analysis with default parameters
+docker run --rm -v /path/to/data:/data getwilds/seurat:latest Rscript /usr/local/bin/seurat_analysis.R \
+  --input_h5=/data/sample_filtered_feature_bc_matrix.h5 \
+  --sample_name=my_sample \
+  --output_prefix=/data/results/my_sample
+
+# Specifying QC thresholds and clustering resolution
+docker run --rm -v /path/to/data:/data getwilds/seurat:latest Rscript /usr/local/bin/seurat_analysis.R \
+  --input_h5=/data/sample_filtered_feature_bc_matrix.h5 \
+  --sample_name=my_sample \
+  --min_cells=5 \
+  --min_features=500 \
+  --max_percent_mt=20.0 \
+  --resolution=0.8 \
+  --ram_gb=16 \
+  --output_prefix=/data/results/my_sample
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/seurat:latest Rscript /usr/local/bin/seurat_analysis.R \
+  --input_h5=/data/sample_filtered_feature_bc_matrix.h5 \
+  --sample_name=my_sample \
+  --output_prefix=/data/results/my_sample
+```
+
+### Script Parameters
+
+#### Seurat Analysis Script (`seurat_analysis.R`)
+
+The included `seurat_analysis.R` script accepts the following parameters:
+
+- `--input_h5`: Path to Cell Ranger filtered feature barcode matrix `.h5` file (required)
+- `--sample_name`: Sample name used for project labeling and default output naming (required)
+- `--min_cells`: Minimum number of cells a gene must be detected in to be retained (default: 3)
+- `--min_features`: Minimum number of features (genes) a cell must have to be retained (default: 200)
+- `--max_percent_mt`: Maximum percent mitochondrial reads allowed per cell (default: 10.0)
+- `--resolution`: Louvain clustering resolution; higher values produce more clusters (default: 0.5)
+- `--output_prefix`: Prefix for all output files; defaults to `--sample_name` if not provided
+- `--ram_gb`: Maximum RAM the script may use in GB, controls `future.globals.maxSize` for parallel operations (default: 4)
+
+### Outputs
+
+The analysis produces the following outputs:
+
+1. `*_qc.png`: Violin plots of QC metrics (nFeature_RNA, nCount_RNA, percent.mt) before filtering
+2. `*_umap.png`: UMAP plot colored and labeled by Louvain cluster
+3. `*_top30_markers.csv`: Top 30 marker genes per cluster ranked by average log2 fold-change
+4. `*_heatmap.png`: Heatmap of the top 8 marker genes per cluster
+5. `*.rds`: Serialized Seurat object with all analysis results embedded
+
+## Analysis Workflow
+
+The `seurat_analysis.R` script performs the following steps:
+
+1. **Load data**: Reads a Cell Ranger `.h5` matrix file using `Read10X_h5()`
+2. **QC filtering**: Computes mitochondrial percentage, plots QC metrics, and removes low-quality cells
+3. **Normalization**: Runs SCTransform with `glmGamPoi` for fast negative binomial regression and mitochondrial percent regression
+4. **Dimensionality reduction**: Runs PCA (30 PCs) followed by UMAP embedding
+5. **Clustering**: Builds a shared nearest-neighbor graph and finds Louvain clusters at the specified resolution
+6. **Marker genes**: Identifies positive marker genes per cluster using Wilcoxon rank-sum test
+7. **Save results**: Writes plots, marker tables, and the Seurat object to disk
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Bioconductor RELEASE_3_21 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs system dependencies (HDF5, FFTW3, GSL) with version pinning
+4. Sets R library paths to avoid host contamination in Apptainer
+5. Installs Seurat, glmGamPoi, and supporting R packages
+6. Copies the analysis script and makes it executable
+7. Sets up a working directory for data analysis
+
+### Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs.txt` file in this directory, which is automatically updated through our GitHub Actions workflow. Critical or high-severity vulnerabilities will also be reported as GitHub issues in the repository.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.

--- a/seurat/seurat_analysis.R
+++ b/seurat/seurat_analysis.R
@@ -70,7 +70,7 @@ message("Cells loaded: ", ncol(seurat_obj))
 ##################
 
 # Get percent mitochondria (assume mitochondiral gene names start with "MT-")
-seurat_obj[["percent.mt"]] <- PercentageFeatureSet(seurat_obj, pattern = "^EN")
+seurat_obj[["percent.mt"]] <- PercentageFeatureSet(seurat_obj, pattern = "^MT-")
 
 # Violin plot of QC metric
 qc_plot <- VlnPlot(seurat_obj,

--- a/seurat/seurat_analysis.R
+++ b/seurat/seurat_analysis.R
@@ -1,0 +1,182 @@
+#!/usr/bin/env Rscript
+
+library(optparse)
+library(Seurat)
+library(ggplot2)
+library(dplyr)
+library(patchwork)
+
+option_list <- list(
+  make_option("--input_h5",
+              type = "character",
+              default = NULL,
+              help = "Path to Cell Ranger .h5 matrix file"),
+  make_option("--sample_name",
+              type = "character",
+              default = NULL,
+              help = "Sample name for labeling outputs"),
+  make_option("--min_cells",
+              type = "integer",
+              default = 3,
+              help = "Min cells per gene"),
+  make_option("--min_features",
+              type = "integer",
+              default = 200,
+              help = "Min features per cell"),
+  make_option("--max_percent_mt",
+              type = "double",
+              default = 10.0,
+              help = "Max mitochondrial percent"),
+  make_option("--resolution",
+              type = "double",
+              default = 0.5,
+              help = "Louvain clustering resolution"),
+  make_option("--output_prefix",
+              type = "character",
+              default = NULL,
+              help = "Prefix for all output files (default: sample_name)"),
+  make_option("--ram_gb",
+              type = "integer",
+              default = 4,
+              help = "Maximum RAM script can use in GB (default: 4)")
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+if (is.null(opt$output_prefix)) opt$output_prefix <- opt$sample_name
+options(future.globals.maxSize = opt$ram_gb * 1024^3)
+
+# Set max RAM usage (important for tasks like SCTransform and FindAllMarkers)
+options(future.globals.maxSize = opt$ram_gb * 1000 * 1024^2)
+
+set.seed(4)
+
+
+#####################
+## 1. Load H5 file ##
+#####################
+
+message("Loading matrix from: ", opt$input_h5)
+counts <- Read10X_h5(opt$input_h5)
+
+seurat_obj <- CreateSeuratObject(counts = counts,
+                                 project = opt$sample_name,
+                                 min.cells = opt$min_cells,
+                                 min.features = opt$min_features)
+message("Cells loaded: ", ncol(seurat_obj))
+
+
+##################
+## 2. QC filter ##
+##################
+
+# Get percent mitochondria (assume mitochondiral gene names start with "MT-")
+seurat_obj[["percent.mt"]] <- PercentageFeatureSet(seurat_obj, pattern = "^EN")
+
+# Violin plot of QC metric
+qc_plot <- VlnPlot(seurat_obj,
+                   features = c("nFeature_RNA", "nCount_RNA", "percent.mt"),
+                   ncol = 3,
+                   pt.size  = 0.1) +
+  plot_annotation(title = paste("Pre-filtering QC Metrics for Sample:", opt$sample_name))
+
+# Save plot
+ggsave(paste0(opt$output_prefix, "_qc.png"),
+       plot = qc_plot,
+       dpi = 300,
+       width = 10,
+       height = 5,
+       device = "png")
+
+# Remove cells outside of user-provided QC threholds
+seurat_obj <- subset(seurat_obj,
+                     subset = nFeature_RNA > opt$min_features &
+                              percent.mt < opt$max_percent_mt)
+message("Cells after QC: ", ncol(seurat_obj))
+
+
+#################################################
+## 3. Normalize with SCTransform and make UMAP ##
+#################################################
+
+# Should have glmGamPoi installed for fast estimation
+seurat_obj <- SCTransform(seurat_obj,
+                          vars.to.regress = "percent.mt",
+                          verbose = FALSE)
+seurat_obj <- RunPCA(seurat_obj, verbose = FALSE)
+seurat_obj <- FindNeighbors(seurat_obj, dims = 1:30)
+seurat_obj <- RunUMAP(seurat_obj, dims = 1:30)
+
+
+################
+## 4. Cluster ##
+################
+
+seurat_obj <- FindClusters(seurat_obj,
+                           resolution = opt$resolution,
+                           verbose = FALSE)
+message("Clusters found: ", length(unique(seurat_obj$seurat_clusters)))
+
+# Make plot of UMAP colored by cluster
+umap_plot <- DimPlot(seurat_obj,
+                     pt.size = 0.4,
+                     label = TRUE,
+                     label.size = 5) +
+  ggtitle(opt$sample_name) +
+  theme(plot.title = element_text(hjust = 0.5),
+        legend.position = "none") +
+  scale_x_discrete("UMAP1") +
+  scale_y_discrete("UMAP2")
+
+# Save plot
+ggsave(paste0(opt$output_prefix, "_umap.png"),
+       plot = umap_plot,
+       dpi = 300,
+       width = 6,
+       height = 6,
+       device = "png")
+
+
+###########################################
+## 5. Find marker genes and make heatmap ##
+###########################################
+
+message("Finding cluster marker genes...")
+markers <- FindAllMarkers(seurat_obj,
+                          only.pos = TRUE,
+                          min.pct = 0.25,
+                          logfc.threshold = 0.25,
+                          verbose = FALSE)
+
+# Store top 30 markers per cluster to be saved for for manual annotation
+top_30_markers <- markers %>%
+  group_by(cluster) %>%
+  slice_max(order_by = avg_log2FC, n = 30)
+
+write.csv(top_30_markers,
+          paste0(opt$output_prefix, "_top30_markers.csv"),
+          row.names = FALSE)
+
+# Store top 8 markers for making the heatmap
+top_8_markers <- markers %>%
+  group_by(cluster) %>%
+  slice_max(order_by = avg_log2FC, n = 8)
+
+# Make a heatmap
+heatmap_plot <- DoHeatmap(seurat_obj, features = top_8_markers$gene) +
+  ggtitle(paste("Top 8 Markers Per Cluster for Sample:", opt$sample_name)) +
+  NoLegend()
+
+ggsave(paste0(opt$output_prefix, "_heatmap.png"),
+       plot = heatmap_plot,
+       dpi = 300,
+       width = 10,
+       height = 8,
+       device = "png")
+
+
+############################
+## 6.  Save Seurat object ##
+############################
+
+saveRDS(seurat_obj, file = paste0(opt$output_prefix, ".rds"))
+message("Done. Output prefix: ", opt$output_prefix)


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a Docker image for Seurat v5.2.1 (Bioconductor 3.21) and supporting packages for single-cell RNA-seq analysis.

- Dockerfile built on Bioconductor base image `bioconductor/bioconductor_docker:RELEASE_3_21`
- Installs Seurat, glmGamPoi, ggplot2, patchwork, dplyr, and optparse
- Bundled `seurat_analysis.R` script runs a full scRNA-seq workflow (QC, SCTransform normalization, PCA/UMAP, Louvain clustering, marker genes) from a Cell Ranger .h5 input
- Sets R library env vars to prevent contamination from host's environment in Apptainer

## Related Issue

Fixes #360 

## Testing

**How did you test these changes?**
Built the image locally and ran seurat_analysis.R with 10X test data (`2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_2500_Wistar_Rat_PBMCs_Singleplex_3p_gem-x_Universal_count_sample_filtered_feature_bc_matrix.h5`).

**Did the tests pass?**
Yes

## Checklist

- [X] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [X] All required OCI metadata labels are present and accurate
- [X] `README.md` is included/updated in the tool directory
- [X] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [X] Image builds successfully for target platform(s)

## Additional Context

I decided to bundle the R script in this image since that's done in the DESeq2 image.
