### PR TITLE
Adding initial version of `mosdepth` WILDS Docker image

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -10,6 +10,7 @@ flax
 hisat2
 manta
 megahit
+mosdepth
 popv
 python-dl
 rmats-turbo

--- a/mosdepth/CVEs_0.3.14.md
+++ b/mosdepth/CVEs_0.3.14.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/mosdepth:0.3.14
+
+Report generated on 2026-05-21 22:59:01 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 23 |
+| 🟢 Low | 2 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `ubuntu:24.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 22 |
+| 🟢 Low | 2 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `ubuntu:25.10`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/mosdepth:0.3.14  │    0C     0H    23M     2L  
+   digest           │  0c0b6f54616d                      │                             
+ Base image         │  ubuntu:24.04                      │    0C     0H    22M     2L  
+ Updated base image │  ubuntu:25.10                      │    0C     0H     0M     0L  
+                    │                                    │                 -22     -2  
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/mosdepth:0.3.14
+    View base image update recommendations → docker scout recommendations getwilds/mosdepth:0.3.14
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/mosdepth:0.3.14 --org <organization>
+```
+</details>

--- a/mosdepth/CVEs_latest.md
+++ b/mosdepth/CVEs_latest.md
@@ -1,0 +1,49 @@
+# Vulnerability Report for getwilds/mosdepth:latest
+
+Report generated on 2026-05-21 22:59:49 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 23 |
+| 🟢 Low | 2 |
+| ⚪ Unknown | 0 |
+
+## 🐳 Base Image
+
+**Image:** `ubuntu:24.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 22 |
+| 🟢 Low | 2 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `ubuntu:25.10`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/mosdepth:latest  │    0C     0H    23M     2L  
+   digest           │  cdc5331c5d96                      │                             
+ Base image         │  ubuntu:24.04                      │    0C     0H    22M     2L  
+ Updated base image │  ubuntu:25.10                      │    0C     0H     0M     0L  
+                    │                                    │                 -22     -2  
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/mosdepth:latest
+    View base image update recommendations → docker scout recommendations getwilds/mosdepth:latest
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/mosdepth:latest --org <organization>
+```
+</details>

--- a/mosdepth/Dockerfile_0.3.14
+++ b/mosdepth/Dockerfile_0.3.14
@@ -1,0 +1,46 @@
+# Using the Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="mosdepth"
+LABEL org.opencontainers.image.description="Docker image for mosdepth, fast BAM/CRAM depth calculation, in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="0.3.14"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set environment for non-interactive installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install runtime dependencies for mosdepth (htslib transitive deps) and download utilities
+RUN apt-get update \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && CA_CERTS_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
+  && ZLIB1G_VERSION=$(apt-cache policy zlib1g | grep Candidate | awk '{print $2}') \
+  && LIBBZ2_VERSION=$(apt-cache policy libbz2-1.0 | grep Candidate | awk '{print $2}') \
+  && LIBLZMA_VERSION=$(apt-cache policy liblzma5 | grep Candidate | awk '{print $2}') \
+  && LIBCURL_VERSION=$(apt-cache policy libcurl4t64 | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  wget="${WGET_VERSION}" \
+  ca-certificates="${CA_CERTS_VERSION}" \
+  zlib1g="${ZLIB1G_VERSION}" \
+  libbz2-1.0="${LIBBZ2_VERSION}" \
+  liblzma5="${LIBLZMA_VERSION}" \
+  libcurl4t64="${LIBCURL_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Download the pre-built mosdepth binary (linux x86_64) from the official release
+RUN wget -q --no-check-certificate -O /usr/local/bin/mosdepth \
+  https://github.com/brentp/mosdepth/releases/download/v0.3.14/mosdepth \
+  && chmod +x /usr/local/bin/mosdepth
+
+# Set default working directory
+WORKDIR /data
+
+# Smoke test to verify mosdepth was installed correctly
+RUN mosdepth --version

--- a/mosdepth/Dockerfile_latest
+++ b/mosdepth/Dockerfile_latest
@@ -1,0 +1,46 @@
+# Using the Ubuntu base image
+FROM ubuntu:24.04
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="mosdepth"
+LABEL org.opencontainers.image.description="Docker image for mosdepth, fast BAM/CRAM depth calculation, in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set environment for non-interactive installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install runtime dependencies for mosdepth (htslib transitive deps) and download utilities
+RUN apt-get update \
+  && WGET_VERSION=$(apt-cache policy wget | grep Candidate | awk '{print $2}') \
+  && CA_CERTS_VERSION=$(apt-cache policy ca-certificates | grep Candidate | awk '{print $2}') \
+  && ZLIB1G_VERSION=$(apt-cache policy zlib1g | grep Candidate | awk '{print $2}') \
+  && LIBBZ2_VERSION=$(apt-cache policy libbz2-1.0 | grep Candidate | awk '{print $2}') \
+  && LIBLZMA_VERSION=$(apt-cache policy liblzma5 | grep Candidate | awk '{print $2}') \
+  && LIBCURL_VERSION=$(apt-cache policy libcurl4t64 | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  wget="${WGET_VERSION}" \
+  ca-certificates="${CA_CERTS_VERSION}" \
+  zlib1g="${ZLIB1G_VERSION}" \
+  libbz2-1.0="${LIBBZ2_VERSION}" \
+  liblzma5="${LIBLZMA_VERSION}" \
+  libcurl4t64="${LIBCURL_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Download the pre-built mosdepth binary (linux x86_64) from the official release
+RUN wget -q --no-check-certificate -O /usr/local/bin/mosdepth \
+  https://github.com/brentp/mosdepth/releases/download/v0.3.14/mosdepth \
+  && chmod +x /usr/local/bin/mosdepth
+
+# Set default working directory
+WORKDIR /data
+
+# Smoke test to verify mosdepth was installed correctly
+RUN mosdepth --version

--- a/mosdepth/README.md
+++ b/mosdepth/README.md
@@ -1,0 +1,112 @@
+# Mosdepth
+
+This directory contains Docker images for [mosdepth](https://github.com/brentp/mosdepth), a fast tool for calculating sequencing coverage depth from BAM or CRAM alignments at per-base, per-region, or per-window resolution.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/mosdepth/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/mosdepth/CVEs_latest.md) )
+- `0.3.14` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/mosdepth/Dockerfile_0.3.14) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/mosdepth/CVEs_0.3.14.md) )
+
+## Image Details
+
+These Docker images are built from Ubuntu 24.04 and include:
+
+- mosdepth v0.3.14: A fast BAM/CRAM coverage calculator that produces per-base, per-region, or windowed depth output in BED-compatible formats.
+- htslib runtime dependencies (`libcurl4`, `zlib1g`, `libbz2-1.0`, `liblzma5`): required by the statically linked mosdepth binary for compressed and remote file I/O.
+
+The image installs the official pre-built Linux x86_64 binary from the upstream GitHub release, keeping the image small and focused on a single primary tool.
+
+> **Platform note:** The upstream project only distributes an x86_64 binary, so these images are built for `linux/amd64` only. ARM64 builds are skipped via `amd64_only_tools.txt`.
+
+## Citation
+
+If you use mosdepth in your research, please cite the original authors:
+
+```
+Pedersen BS, Quinlan AR. Mosdepth: quick coverage calculation for genomes and
+exomes. Bioinformatics. 2018 Mar 1;34(5):867-868.
+doi:10.1093/bioinformatics/btx699
+```
+
+**Tool homepage:** https://github.com/brentp/mosdepth
+
+**Publication:** https://doi.org/10.1093/bioinformatics/btx699
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/mosdepth:latest
+
+# Or pull a specific version
+docker pull getwilds/mosdepth:0.3.14
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/mosdepth:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/mosdepth:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/mosdepth:0.3.14
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/mosdepth:latest
+```
+
+### Example Commands
+
+```bash
+# Per-base coverage across the whole genome
+docker run --rm -v /path/to/data:/data getwilds/mosdepth:latest \
+  mosdepth /data/sample sample.bam
+
+# Per-region coverage using a BED of target intervals (e.g., exome capture)
+docker run --rm -v /path/to/data:/data getwilds/mosdepth:latest \
+  mosdepth --by /data/targets.bed /data/sample_exome /data/sample.bam
+
+# Fixed-size 500 bp windows with no per-base output, using 4 threads
+docker run --rm -v /path/to/data:/data getwilds/mosdepth:latest \
+  mosdepth --no-per-base --by 500 --threads 4 /data/sample_windows /data/sample.bam
+
+# CRAM input requires a reference FASTA
+docker run --rm -v /path/to/data:/data getwilds/mosdepth:latest \
+  mosdepth --fasta /data/reference.fa /data/sample_cram /data/sample.cram
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/mosdepth:latest \
+  mosdepth --by /data/targets.bed /data/sample_exome /data/sample.bam
+
+# ... or a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data mosdepth_latest.sif \
+  mosdepth /data/sample /data/sample.bam
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Ubuntu 24.04 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Dynamically determines and pins the latest security-patched versions of the runtime dependencies mosdepth needs (htslib's compression and HTTPS libraries)
+4. Downloads the official pre-built `mosdepth` binary from the upstream GitHub release and installs it to `/usr/local/bin`
+5. Sets `/data` as the default working directory for analyses
+6. Runs `mosdepth --version` as a smoke test to verify the install
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/mosdepth), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new WILDS Docker image for [mosdepth](https://github.com/brentp/mosdepth), a fast tool for calculating sequencing coverage depth from BAM/CRAM alignments at per-base, per-region, or windowed resolution (Pedersen & Quinlan, *Bioinformatics* 2018).

- **Tool version:** mosdepth 0.3.14 (latest upstream release)
- **Base image:** `ubuntu:24.04`
- **Install method:** Official pre-built static x86_64 binary downloaded from the GitHub release to `/usr/local/bin/mosdepth`
- **Runtime deps (pinned via `apt-cache policy`):** `wget`, `ca-certificates`, `zlib1g`, `libbz2-1.0`, `liblzma5`, `libcurl4t64` — htslib's compression and HTTPS transitive deps
- **Final image size:** ~106 MB
- **Files added:** `mosdepth/Dockerfile_latest`, `mosdepth/Dockerfile_0.3.14`, `mosdepth/README.md`
- **Also updated:** `amd64_only_tools.txt` — mosdepth added so the ARM64 build is skipped (see Additional Context)

## Testing

**How did you test these changes?**

- `make lint IMAGE=mosdepth` — both Dockerfiles pass hadolint with no warnings
- `make build_amd64 IMAGE=mosdepth` — both `Dockerfile_latest` and `Dockerfile_0.3.14` build successfully and the in-build smoke test `mosdepth --version` reports `mosdepth 0.3.14`

**Did the tests pass?**

Yes. Lint clean, build green, smoke test green on linux/amd64.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

**AMD64 only.** Upstream mosdepth only publishes a `linux/amd64` binary, so mosdepth is added to `amd64_only_tools.txt` to skip ARM64 builds — same pattern smoove already uses for the mosdepth it bundles.