### PR TITLE
Adding lexical/semantic eval tools to Ollama Docker image

### DIFF
--- a/ollama/CVEs_0.21.0.md
+++ b/ollama/CVEs_0.21.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:0.21.0
 
-Report generated on 2026-05-22 18:48:05 PST
+Report generated on 2026-05-26 17:17:29 PST
 
 ## Platform Coverage
 

--- a/ollama/CVEs_0.21.0.md
+++ b/ollama/CVEs_0.21.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:0.21.0
 
-Report generated on 2026-05-26 19:35:39 PST
+Report generated on 2026-05-27 16:48:59 PST
 
 ## Platform Coverage
 

--- a/ollama/CVEs_0.21.0.md
+++ b/ollama/CVEs_0.21.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:0.21.0
 
-Report generated on 2026-05-21 20:36:02 PST
+Report generated on 2026-05-22 18:48:05 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 3.7 GB
+**Image size:** 4.1 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/ollama/CVEs_0.21.0.md
+++ b/ollama/CVEs_0.21.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:0.21.0
 
-Report generated on 2026-05-26 17:17:29 PST
+Report generated on 2026-05-26 19:35:39 PST
 
 ## Platform Coverage
 

--- a/ollama/CVEs_latest.md
+++ b/ollama/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:latest
 
-Report generated on 2026-05-26 17:52:42 PST
+Report generated on 2026-05-26 20:12:02 PST
 
 ## Platform Coverage
 

--- a/ollama/CVEs_latest.md
+++ b/ollama/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:latest
 
-Report generated on 2026-05-26 20:12:02 PST
+Report generated on 2026-05-27 17:21:13 PST
 
 ## Platform Coverage
 

--- a/ollama/CVEs_latest.md
+++ b/ollama/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:latest
 
-Report generated on 2026-05-22 19:21:27 PST
+Report generated on 2026-05-26 17:52:42 PST
 
 ## Platform Coverage
 

--- a/ollama/CVEs_latest.md
+++ b/ollama/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/ollama:latest
 
-Report generated on 2026-05-21 20:50:21 PST
+Report generated on 2026-05-22 19:21:27 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 3.7 GB
+**Image size:** 4.1 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/ollama/Dockerfile_0.21.0
+++ b/ollama/Dockerfile_0.21.0
@@ -39,7 +39,9 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     sentence-transformers==5.5.1 \
     llama-index-embeddings-huggingface==0.7.0
 
-RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+ENV HF_HOME=/opt/hf_cache
+RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" \
+  && chmod -R a+rX /opt/hf_cache
 
 ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0

--- a/ollama/Dockerfile_0.21.0
+++ b/ollama/Dockerfile_0.21.0
@@ -39,6 +39,8 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     sentence-transformers==5.5.1 \
     llama-index-embeddings-huggingface==0.7.0
 
+RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+
 ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
@@ -67,6 +69,7 @@ RUN ollama --version \
   && python3 -c "import torch; assert not torch.cuda.is_available()" \
   && python3 -c "import sentence_transformers" \
   && python3 -c "from llama_index.embeddings.huggingface import HuggingFaceEmbedding" \
+  && HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2').encode(['ok'])" \
   && sprocket --version \
   && opencode --version \
   && git --version \

--- a/ollama/Dockerfile_0.21.0
+++ b/ollama/Dockerfile_0.21.0
@@ -36,8 +36,7 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     ollama==0.6.1 \
     chromadb==1.5.9 \
     rapidfuzz==3.14.5 \
-    sentence-transformers==5.5.1 \
-    llama-index-embeddings-huggingface==0.7.0
+    sentence-transformers==5.5.1
 
 ENV HF_HOME=/opt/hf_cache
 RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" \
@@ -70,7 +69,6 @@ RUN ollama --version \
   && python3 -c "import rapidfuzz" \
   && python3 -c "import torch; assert not torch.cuda.is_available()" \
   && python3 -c "import sentence_transformers" \
-  && python3 -c "from llama_index.embeddings.huggingface import HuggingFaceEmbedding" \
   && HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2').encode(['ok'])" \
   && sprocket --version \
   && opencode --version \

--- a/ollama/Dockerfile_0.21.0
+++ b/ollama/Dockerfile_0.21.0
@@ -30,8 +30,14 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages \
-  ollama==0.6.1 \
-  chromadb==1.5.9
+    --index-url https://download.pytorch.org/whl/cpu \
+    torch==2.12.0+cpu \
+  && pip3 install --no-cache-dir --break-system-packages \
+    ollama==0.6.1 \
+    chromadb==1.5.9 \
+    rapidfuzz==3.14.5 \
+    sentence-transformers==5.5.1 \
+    llama-index-embeddings-huggingface==0.7.0
 
 ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0
@@ -54,7 +60,18 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
   && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin opencode \
   && rm /tmp/opencode.tar.gz
 
-RUN ollama --version && python3 -c "import ollama" && python3 -c "import chromadb" && sprocket --version && opencode --version && git --version && which ssh && rg --version
+RUN ollama --version \
+  && python3 -c "import ollama" \
+  && python3 -c "import chromadb" \
+  && python3 -c "import rapidfuzz" \
+  && python3 -c "import torch; assert not torch.cuda.is_available()" \
+  && python3 -c "import sentence_transformers" \
+  && python3 -c "from llama_index.embeddings.huggingface import HuggingFaceEmbedding" \
+  && sprocket --version \
+  && opencode --version \
+  && git --version \
+  && which ssh \
+  && rg --version
 
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/ollama/Dockerfile_latest
+++ b/ollama/Dockerfile_latest
@@ -39,7 +39,9 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     sentence-transformers==5.5.1 \
     llama-index-embeddings-huggingface==0.7.0
 
-RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+ENV HF_HOME=/opt/hf_cache
+RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" \
+  && chmod -R a+rX /opt/hf_cache
 
 ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0

--- a/ollama/Dockerfile_latest
+++ b/ollama/Dockerfile_latest
@@ -39,6 +39,8 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     sentence-transformers==5.5.1 \
     llama-index-embeddings-huggingface==0.7.0
 
+RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')"
+
 ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
@@ -67,6 +69,7 @@ RUN ollama --version \
   && python3 -c "import torch; assert not torch.cuda.is_available()" \
   && python3 -c "import sentence_transformers" \
   && python3 -c "from llama_index.embeddings.huggingface import HuggingFaceEmbedding" \
+  && HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2').encode(['ok'])" \
   && sprocket --version \
   && opencode --version \
   && git --version \

--- a/ollama/Dockerfile_latest
+++ b/ollama/Dockerfile_latest
@@ -36,8 +36,7 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     ollama==0.6.1 \
     chromadb==1.5.9 \
     rapidfuzz==3.14.5 \
-    sentence-transformers==5.5.1 \
-    llama-index-embeddings-huggingface==0.7.0
+    sentence-transformers==5.5.1
 
 ENV HF_HOME=/opt/hf_cache
 RUN python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')" \
@@ -70,7 +69,6 @@ RUN ollama --version \
   && python3 -c "import rapidfuzz" \
   && python3 -c "import torch; assert not torch.cuda.is_available()" \
   && python3 -c "import sentence_transformers" \
-  && python3 -c "from llama_index.embeddings.huggingface import HuggingFaceEmbedding" \
   && HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python3 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2').encode(['ok'])" \
   && sprocket --version \
   && opencode --version \

--- a/ollama/Dockerfile_latest
+++ b/ollama/Dockerfile_latest
@@ -30,8 +30,14 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --no-cache-dir --break-system-packages \
-  ollama==0.6.1 \
-  chromadb==1.5.9
+    --index-url https://download.pytorch.org/whl/cpu \
+    torch==2.12.0+cpu \
+  && pip3 install --no-cache-dir --break-system-packages \
+    ollama==0.6.1 \
+    chromadb==1.5.9 \
+    rapidfuzz==3.14.5 \
+    sentence-transformers==5.5.1 \
+    llama-index-embeddings-huggingface==0.7.0
 
 ARG TARGETARCH
 ARG SPROCKET_VERSION=0.23.0
@@ -54,7 +60,18 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
   && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin opencode \
   && rm /tmp/opencode.tar.gz
 
-RUN ollama --version && python3 -c "import ollama" && python3 -c "import chromadb" && sprocket --version && opencode --version && git --version && which ssh && rg --version
+RUN ollama --version \
+  && python3 -c "import ollama" \
+  && python3 -c "import chromadb" \
+  && python3 -c "import rapidfuzz" \
+  && python3 -c "import torch; assert not torch.cuda.is_available()" \
+  && python3 -c "import sentence_transformers" \
+  && python3 -c "from llama_index.embeddings.huggingface import HuggingFaceEmbedding" \
+  && sprocket --version \
+  && opencode --version \
+  && git --version \
+  && which ssh \
+  && rg --version
 
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -20,6 +20,7 @@ These Docker images are built from `ollama/ollama:0.21.0` and include:
 - sentence-transformers v5.5.1: sentence/text embedding models for semantic similarity
 - PyTorch v2.12.0 (CPU build): tensor library underlying sentence-transformers — installed from the PyTorch CPU wheel index so CUDA wheels are not pulled in (Ollama owns the GPU; the embedding model runs on CPU)
 - llama-index-embeddings-huggingface v0.7.0: LlamaIndex adapter for HuggingFace embedding models
+- `sentence-transformers/all-MiniLM-L6-v2` model (~91MB) pre-cached under `/root/.cache/huggingface` so the image is self-contained and the embedding model can be loaded offline (`HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`)
 - Python 3 (system version from base image)
 - git, openssh-client, and ripgrep (system versions from base image) — supporting tools for repository workflows and fast code search used by OpenCode
 

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -1,6 +1,6 @@
 # Ollama
 
-This directory contains Docker images for [Ollama](https://ollama.com/), an LLM inference server, bundled with the [Sprocket](https://github.com/stjude-rust-labs/sprocket) WDL validator, the [Python ollama SDK](https://pypi.org/project/ollama/), [OpenCode](https://github.com/sst/opencode), an open-source AI coding agent, and [ChromaDB](https://www.trychroma.com/), an open-source vector database tool. Designed for benchmarking LLM-generated WDL scripts.
+This directory contains Docker images for [Ollama](https://ollama.com/), an LLM inference server, bundled with the [Sprocket](https://github.com/stjude-rust-labs/sprocket) WDL validator, the [Python ollama SDK](https://pypi.org/project/ollama/), [OpenCode](https://github.com/sst/opencode), an open-source AI coding agent, and [ChromaDB](https://www.trychroma.com/), an open-source vector database tool. Also includes lexical/semantic similarity evaluation support via [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz), [sentence-transformers](https://www.sbert.net/), and a CPU-only build of [PyTorch](https://pytorch.org/) (with [llama-index-embeddings-huggingface](https://pypi.org/project/llama-index-embeddings-huggingface/) for embedding-model loading). Designed for benchmarking LLM-generated WDL scripts.
 
 ## Available Versions
 
@@ -16,6 +16,10 @@ These Docker images are built from `ollama/ollama:0.21.0` and include:
 - OpenCode v1.14.39: open-source AI coding agent
 - Python ollama SDK v0.6.1: Python client library for interacting with Ollama
 - chromadb v1.5.9: open-source vector database for embeddings and RAG workflows
+- RapidFuzz v3.14.5: fast string similarity scoring for lexical evaluation
+- sentence-transformers v5.5.1: sentence/text embedding models for semantic similarity
+- PyTorch v2.12.0 (CPU build): tensor library underlying sentence-transformers — installed from the PyTorch CPU wheel index so CUDA wheels are not pulled in (Ollama owns the GPU; the embedding model runs on CPU)
+- llama-index-embeddings-huggingface v0.7.0: LlamaIndex adapter for HuggingFace embedding models
 - Python 3 (system version from base image)
 - git, openssh-client, and ripgrep (system versions from base image) — supporting tools for repository workflows and fast code search used by OpenCode
 
@@ -31,12 +35,14 @@ A GPU is not required to run this image, but is highly encouraged — CPU-only e
 
 ## Citation
 
-This image bundles four independent tools. If you use them in your research, please cite the original authors:
+This image bundles several independent tools. If you use them in your research, please cite the original authors:
 
 - **Ollama** (LLM inference server): https://ollama.com/
 - **Sprocket** (WDL execution engine): https://github.com/stjude-rust-labs/sprocket
 - **OpenCode** (AI coding agent): https://github.com/sst/opencode
 - **Chroma** (vector database): https://www.trychroma.com/
+- **sentence-transformers** (semantic text embeddings): Reimers, N., & Gurevych, I. (2019). Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks. https://www.sbert.net/
+- **PyTorch** (tensor/ML framework): Paszke, A., et al. (2019). PyTorch: An Imperative Style, High-Performance Deep Learning Library. https://pytorch.org/
 
 ## Usage
 
@@ -102,7 +108,7 @@ The Dockerfile follows these main steps:
 1. Uses `ollama/ollama:0.21.0` as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs system dependencies with pinned versions (Python, curl, git, openssh-client, ripgrep)
-4. Installs the Python ollama SDK and chromadb via pip
+4. Installs CPU-only PyTorch from the PyTorch CPU wheel index, then the Python ollama SDK, chromadb, RapidFuzz, sentence-transformers, and llama-index-embeddings-huggingface via pip
 5. Downloads the prebuilt Sprocket binary for the target architecture
 6. Downloads the prebuilt OpenCode binary for the target architecture
 7. Runs smoke tests to verify all tools are installed correctly

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -20,7 +20,7 @@ These Docker images are built from `ollama/ollama:0.21.0` and include:
 - sentence-transformers v5.5.1: sentence/text embedding models for semantic similarity
 - PyTorch v2.12.0 (CPU build): tensor library underlying sentence-transformers — installed from the PyTorch CPU wheel index so CUDA wheels are not pulled in (Ollama owns the GPU; the embedding model runs on CPU)
 - llama-index-embeddings-huggingface v0.7.0: LlamaIndex adapter for HuggingFace embedding models
-- `sentence-transformers/all-MiniLM-L6-v2` model (~91MB) pre-cached under `/root/.cache/huggingface` so the image is self-contained and the embedding model can be loaded offline (`HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`)
+- `sentence-transformers/all-MiniLM-L6-v2` model (~91MB) pre-cached under `/opt/hf_cache` (world-readable, so it works under Apptainer's non-root execution model) — `HF_HOME` is set to that path in the image, so the embedding model can be loaded offline (`HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`); point `HF_HOME=/opt/hf_cache` explicitly if your runtime overrides it
 - Python 3 (system version from base image)
 - git, openssh-client, and ripgrep (system versions from base image) — supporting tools for repository workflows and fast code search used by OpenCode
 

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -1,6 +1,6 @@
 # Ollama
 
-This directory contains Docker images for [Ollama](https://ollama.com/), an LLM inference server, bundled with the [Sprocket](https://github.com/stjude-rust-labs/sprocket) WDL validator, the [Python ollama SDK](https://pypi.org/project/ollama/), [OpenCode](https://github.com/sst/opencode), an open-source AI coding agent, and [ChromaDB](https://www.trychroma.com/), an open-source vector database tool. Also includes lexical/semantic similarity evaluation support via [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz), [sentence-transformers](https://www.sbert.net/), and a CPU-only build of [PyTorch](https://pytorch.org/) (with [llama-index-embeddings-huggingface](https://pypi.org/project/llama-index-embeddings-huggingface/) for embedding-model loading). Designed for benchmarking LLM-generated WDL scripts.
+This directory contains Docker images for [Ollama](https://ollama.com/), an LLM inference server, bundled with the [Sprocket](https://github.com/stjude-rust-labs/sprocket) WDL validator, the [Python ollama SDK](https://pypi.org/project/ollama/), [OpenCode](https://github.com/sst/opencode), an open-source AI coding agent, and [ChromaDB](https://www.trychroma.com/), an open-source vector database tool. Also includes lexical/semantic similarity evaluation support via [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz), [sentence-transformers](https://www.sbert.net/), and a CPU-only build of [PyTorch](https://pytorch.org/). Designed for benchmarking LLM-generated WDL scripts.
 
 ## Available Versions
 
@@ -19,7 +19,6 @@ These Docker images are built from `ollama/ollama:0.21.0` and include:
 - RapidFuzz v3.14.5: fast string similarity scoring for lexical evaluation
 - sentence-transformers v5.5.1: sentence/text embedding models for semantic similarity
 - PyTorch v2.12.0 (CPU build): tensor library underlying sentence-transformers — installed from the PyTorch CPU wheel index so CUDA wheels are not pulled in (Ollama owns the GPU; the embedding model runs on CPU)
-- llama-index-embeddings-huggingface v0.7.0: LlamaIndex adapter for HuggingFace embedding models
 - `sentence-transformers/all-MiniLM-L6-v2` model (~91MB) pre-cached under `/opt/hf_cache` (world-readable, so it works under Apptainer's non-root execution model) — `HF_HOME` is set to that path in the image, so the embedding model can be loaded offline (`HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`); point `HF_HOME=/opt/hf_cache` explicitly if your runtime overrides it
 - Python 3 (system version from base image)
 - git, openssh-client, and ripgrep (system versions from base image) — supporting tools for repository workflows and fast code search used by OpenCode
@@ -109,7 +108,7 @@ The Dockerfile follows these main steps:
 1. Uses `ollama/ollama:0.21.0` as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs system dependencies with pinned versions (Python, curl, git, openssh-client, ripgrep)
-4. Installs CPU-only PyTorch from the PyTorch CPU wheel index, then the Python ollama SDK, chromadb, RapidFuzz, sentence-transformers, and llama-index-embeddings-huggingface via pip
+4. Installs CPU-only PyTorch from the PyTorch CPU wheel index, then the Python ollama SDK, chromadb, RapidFuzz, and sentence-transformers via pip
 5. Downloads the prebuilt Sprocket binary for the target architecture
 6. Downloads the prebuilt OpenCode binary for the target architecture
 7. Runs smoke tests to verify all tools are installed correctly


### PR DESCRIPTION
## Type of Change

- Version update (extends an existing image's bundled tooling)
- Documentation update

## Description

Adds the Python dependencies needed by the WDL functional-eval pipeline (lexical/semantic similarity scoring) directly into the `getwilds/ollama` image, so callers no longer have to `pip install` them (or download the embedding model) at runtime. Previously, `wilds-wdl-writer`'s `wdl_writer/benchmarking.py` (run via `benchmarking.wdl`) crashed on import because the image only shipped `ollama` and `chromadb`, and even after the deps were in place the embedding model still had to be pulled on every run.

Bundled packages, with pins matching a fresh install today:

- `rapidfuzz==3.14.5`: fast string similarity for lexical eval.
- `sentence-transformers==5.5.1`: embedding models for semantic similarity.
- `torch==2.12.0+cpu`: installed first from `https://download.pytorch.org/whl/cpu` so the CUDA wheels (multi-GB) are skipped.

Pre-cached model:

- `sentence-transformers/all-MiniLM-L6-v2` (~91MB) is downloaded at build time into `/opt/hf_cache` (with `chmod -R a+rX` so non-root processes can read it), and `HF_HOME` is set in the image. The smoke test loads it with `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1` to catch regressions where the offline path breaks.

Applied identically to `Dockerfile_0.21.0` and `Dockerfile_latest`. README updated: intro mentions lexical/semantic eval support, Image Details and Dockerfile Structure list the new packages and pre-cached model location, and citations were added for sentence-transformers and PyTorch.

Additional context: getwilds/wilds-wdl-writer#19.

## Testing

**How did you test these changes?**

- `make lint IMAGE=ollama`: hadolint passes on both Dockerfiles.
- Built the image locally and confirmed it comes up cleanly. The expanded smoke test exercises every new import (`rapidfuzz`, `torch` + CPU-only assertion, `sentence_transformers`) and, critically, loads the pre-cached embedding model with `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1` as part of the build, so the image fails to build if the offline path regresses.
- Also successfully ran the benchmarking WDL with the new version of the image.

**Did the tests pass?**

Yes, lint clean and local build succeeded.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)