### PR TITLE
Restricting the Seurat image to AMD64 only

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -15,6 +15,7 @@ python-dl
 rmats-turbo
 rtorch
 scvi-tools
+seurat
 shapemapper
 smoove
 spades

--- a/seurat/README.md
+++ b/seurat/README.md
@@ -18,6 +18,10 @@ These Docker images are built from the Bioconductor base image and include:
 - optparse: For command-line interface
 - A script that performs standard gene expression scRNA-seq processing (see below)
 
+## Platform Availability
+
+**Note:** This image is only built for **linux/amd64** architecture. The Bioconductor base image does not provide ARM64 binaries, so Seurat and its dependencies must be compiled from source under emulation, which causes ARM64 builds to exceed the 6-hour GitHub Actions timeout.
+
 ## Usage
 
 ### Docker


### PR DESCRIPTION
## Type of Change

- CI/CD or workflow change
- Documentation update

## Description

Restricts the Seurat image to `linux/amd64` only by adding `seurat` to `amd64_only_tools.txt`, and documents the limitation in `seurat/README.md`.

The `bioconductor/bioconductor_docker:RELEASE_3_21` base image only publishes AMD64 binaries, so ARM64 builds fall back to QEMU emulation and compile Seurat plus its full dependency tree from source. This was causing the build-and-push GitHub Action to exceed the 6-hour timeout and cancel before finishing. This matches the existing handling for other Bioconductor-based images like `deseq2`.

## Testing

**How did you test these changes?**

No build testing required, this is a configuration and docs change.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (already successfully built in AMD64 in previous runs)
- [x] Image builds successfully for target platform(s)
