### PR TITLE
Adding initial draft of agentic framework

### DIFF
--- a/.agents/skills/fix-cves/SKILL.md
+++ b/.agents/skills/fix-cves/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: fix-cves
+description: Identify and remediate CVEs in WILDS Docker images
+argument-hint: <tool-name> | worst | (blank)
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Fix CVEs in Docker Images
+
+Identify and remediate vulnerabilities in WILDS Docker images. The argument can be:
+
+- A specific tool name (e.g., `samtools`) — fix CVEs for that image
+- `worst` or left blank — scan all CVE reports, rank images by severity, and fix the worst offenders
+
+## Steps
+
+### 1. Identify Target Images
+
+**If a specific tool was provided:**
+
+- Read `<tool>/CVEs_latest.md` to understand the current vulnerability landscape
+
+**If `worst` or blank:**
+
+- Read all `*/CVEs_latest.md` files across the repo
+- Rank images by CVE severity (Critical > High > Medium > Low) and count
+- Present a summary table of the top 5-10 worst images to the user
+- Ask the user which image(s) to fix, or proceed with the worst one
+
+### 2. Analyze CVE Sources
+
+For each target image, determine where the vulnerabilities come from by reading the CVE report carefully:
+
+- **Base image CVEs** — shown in the "Base Image" section of the report; fixed by upgrading the base image (e.g., `ubuntu:22.04` to `ubuntu:24.04`, or refreshing to a newer digest)
+- **Tool/dependency CVEs** — the difference between total CVEs and base image CVEs; come from the tool itself or packages installed on top of the base image
+- **Check the "Recommendations" section** for suggested base image updates
+
+### 3. Determine Fixable Actions
+
+Read the tool's `Dockerfile_latest` and consider these remediation strategies in order of impact:
+
+1. **Upgrade the base image** if the report recommends a refreshed or updated base image
+2. **Upgrade the tool version** if a newer version exists that might pull in fewer vulnerable dependencies
+3. **Remove unnecessary packages** — check if build-only dependencies are left in the final image
+4. **Add `apt-get upgrade`** as a last resort for system-level patches (after `apt-get update`, before installing packages)
+5. **Switch to a slimmer base** if appropriate (e.g., `python:3.x` to `python:3.x-slim`)
+
+### 4. Apply Fixes
+
+- Make changes to `Dockerfile_latest` and any corresponding `Dockerfile_X.Y.Z`
+- Preserve the existing installation method and structure as much as possible
+- Ensure all Dockerfile requirements from `AGENTS.md` are still met
+
+### 5. Lint and Build
+
+- Run `make lint IMAGE=<toolname>` and fix any issues
+- Run `make build_amd64 IMAGE=<toolname>` and fix any build failures
+
+### 6. Assess Impact
+
+After a successful build, if Docker Scout is available locally, run:
+
+```bash
+docker scout quickview getwilds/<toolname>:latest-amd64
+```
+
+to compare the new vulnerability count against the old report. If Docker Scout is not available locally, note that the user should check after pushing to verify improvement.
+
+### 7. Summary
+
+Report:
+
+- Which image(s) were fixed
+- What changes were made (base image upgrade, tool upgrade, dependency removal, etc.)
+- CVE counts before the fix (from the report)
+- Expected impact of the changes
+- Any CVEs that are NOT fixable through Dockerfile changes (e.g., vulnerabilities in the tool's own code that require an upstream fix)
+- Confirmation that lint and build passed

--- a/.agents/skills/new-image/SKILL.md
+++ b/.agents/skills/new-image/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: new-image
+description: Create a new Docker image for a bioinformatics tool
+argument-hint: <tool-name>
+allowed-tools: Bash, Read, Glob, Grep, WebSearch, WebFetch
+---
+
+# Create a New Docker Image
+
+Scaffold and build a new WILDS Docker image for an open-source bioinformatics tool.
+
+## Steps
+
+### 1. Research the Tool
+
+Before writing any files, research the tool to understand:
+
+- What it does and what it is used for
+- The latest stable version available
+- How it is typically installed (apt, conda/mamba, pip, compiled from source, pre-built binary/JAR, etc.)
+- What base image is most appropriate (`ubuntu:24.04`, `condaforge/miniforge3`, `bioconductor/bioconductor_docker`, `python:3.x-slim`, etc.)
+- Its official homepage and citation information
+- What dependencies it requires
+
+### 2. Create the Tool Directory and Dockerfile
+
+- Create a new directory named after the tool (lowercase, hyphens for multi-word names)
+- Read `template/Dockerfile_template` first as the formatting reference
+- Create `Dockerfile_latest` following ALL Dockerfile requirements from `AGENTS.md`:
+  - OCI metadata labels (title, description, version, authors, source URL, MIT license)
+  - `SHELL ["/bin/bash", "-o", "pipefail", "-c"]`
+  - Pinned versions for system packages using `apt-cache policy`
+  - A smoke test `RUN` command verifying the install (e.g., `tool --version`)
+  - Cleanup steps (`rm -rf /var/lib/apt/lists/*`, `mamba clean -afy`, remove tarballs, etc.)
+- Also create `Dockerfile_X.Y.Z` for the specific version (may be identical to latest)
+- Target image size: a few hundred MB, max 2GB. One primary tool per image.
+
+### 3. Create the README
+
+- Read `template/README.md` first as the formatting reference
+- Fill in all standard sections: description, available versions, image details, citation, Docker/Apptainer usage, example commands, Dockerfile structure, security/CVE info, and source repository
+- Remove any optional sections that do not apply
+- Remove ALL HTML comments and template instructions from the final README
+- Provide realistic example commands
+
+### 4. Lint the Dockerfile
+
+Run `make lint IMAGE=<toolname>` to check for hadolint issues. Fix any warnings or errors before proceeding.
+
+### 5. Build and Test
+
+Run `make build_amd64 IMAGE=<toolname>` to verify the image builds successfully. Diagnose and fix any failures, then re-run until it passes.
+
+### 6. Summary
+
+After all steps pass, report:
+
+- The tool version packaged
+- The base image used
+- The installation method chosen
+- Any notable decisions or trade-offs made
+- Confirmation that lint and build passed

--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: pr-description
+description: Draft a pull request description using the project's PR template
+argument-hint: [optional branch or description context]
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Draft a Pull Request Description
+
+Generate a PR description following the project's PR template at `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Steps
+
+### 1. Gather Context
+
+- Read `.github/PULL_REQUEST_TEMPLATE.md` to get the template format
+- Run `git log --oneline main..HEAD` to see all commits on the current branch
+- Run `git diff --stat main..HEAD` to understand what files changed
+- Optionally read changed files to understand the nature of the changes
+
+### 2. Draft the PR Description
+
+Fill in the PR template sections based on the changes:
+
+- **Type of Change**: Infer from the changes (new Docker image, version update, CVE fix, documentation update, CI/CD change, etc.)
+- **Description**: Summarize what was added or changed and why, including the tool version, base image, and installation method for new images; or what changed and the motivation for updates
+- **Related Issue**: Leave as a placeholder unless context is provided
+- **Testing**: Describe how the changes were tested based on what you can infer from the conversation or branch history (e.g., `make lint`, `make build_amd64`, `make validate`)
+- **Checklist**: Check off items that are satisfied based on the diff
+
+### 3. Output
+
+Present the draft PR description inside a single markdown code block (` ```markdown ... ``` `) so the user can easily copy the raw markdown directly into GitHub. Do NOT render it as formatted text outside a code block. Do NOT create any git commits or push to GitHub.

--- a/.agents/skills/update-image/SKILL.md
+++ b/.agents/skills/update-image/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: update-image
+description: Update an existing WILDS Docker image to a new version
+argument-hint: <tool-name> [version]
+allowed-tools: Bash, Read, Glob, Grep, WebSearch, WebFetch
+---
+
+# Update an Existing Docker Image
+
+Update a WILDS Docker image to a new version. The argument can be:
+
+- Just a tool name (e.g., `samtools`) — automatically find and update to the latest available version
+- A tool name and version (e.g., `samtools 1.21`) — update to that specific version
+
+## Steps
+
+### 1. Understand the Current State
+
+- Read the existing `Dockerfile_latest` in the tool's directory to understand the current version, base image, installation method, and structure
+- Read the tool's `README.md` to understand what is documented
+- Identify the current version from the Dockerfile (look at download URLs, version labels, etc.)
+
+### 2. Determine the Target Version
+
+- If a specific version was provided, use that
+- If only a tool name was provided, research the tool's releases to find the latest stable version
+- If the tool is already at the latest version, report that and stop — no changes needed
+
+### 3. Create or Update Version-Specific Dockerfile
+
+- If a `Dockerfile_X.Y.Z` for the NEW version does not exist, create one based on `Dockerfile_latest` with the new version number
+- If the old `Dockerfile_latest` pointed to a version that does not have its own pinned Dockerfile yet, consider whether one should be created for the old version before updating (check what version-specific files already exist)
+
+### 4. Update Dockerfile_latest
+
+- Update the version in download URLs, build commands, and any version-specific paths
+- Update the `org.opencontainers.image.version` label if it contains the version number (keep it as "latest" if that is the convention used)
+- Keep the same installation method and structure — do not refactor unless necessary
+- Ensure all Dockerfile requirements from `AGENTS.md` are still met
+
+### 5. Update the README
+
+- Add the new version to the "Available Versions" table
+- Update any version references in the "Image Details" section
+- Do NOT remove old versions from the table — they should remain listed
+
+### 6. Lint and Build
+
+- Run `make lint IMAGE=<toolname>` and fix any issues
+- Run `make build_amd64 IMAGE=<toolname>` and fix any build failures
+
+### 7. Summary
+
+Report what changed:
+
+- Previous version vs. new version
+- Files created or modified
+- Any issues encountered and how they were resolved
+- Confirmation that lint and build passed

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -423,6 +423,19 @@ Once your PR is submitted:
 4. Address any requested changes
 5. Once approved and merged, images are automatically published to DockerHub and GHCR
 
+## AI-Assisted Development
+
+We occasionally use large language models to assist with prototyping new images and updating existing ones, and contributors are welcome to do the same. However, all AI-generated code must go through the same linting, building, and human review process as any other contribution. Please ensure you review and understand any AI-generated Dockerfiles before submitting them in a PR.
+
+To make AI assistance more consistent with project conventions, the repository ships an [`AGENTS.md`](../AGENTS.md) project-context file (following the vendor-neutral [agents.md](https://agents.md/) convention) and a set of reusable task recipes under [`.agents/skills/`](../.agents/skills/):
+
+- `new-image` — create a new Docker image for a bioinformatics tool
+- `update-image` — update an existing image to a new version
+- `fix-cves` — identify and remediate CVEs in an existing image
+- `pr-description` — draft a PR description from the current branch
+
+Tools that follow the AGENTS.md convention (OpenCode, Claude Code, and others) discover these files automatically. Use of these tools is optional — they are provided as a convenience and do not replace the testing and review requirements above.
+
 ## Help for New Contributors
 
 New contributors are welcome! If you're new to Docker or bioinformatics containers:

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .RData
 .Ruserdata
 notes/
+.DS_Store
 CLAUDE.md
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md - WILDS Docker Library
+
+## Project Overview
+
+Curated Docker images for bioinformatics tools, maintained by Fred Hutch's Office of the Chief Data Officer (OCDO). Each image targets one primary tool and is published to DockerHub and GHCR under the `getwilds/` namespace.
+
+## Repo Structure
+
+```
+toolname/
+├── Dockerfile_X.Y.Z    # specific version → getwilds/toolname:X.Y.Z
+├── Dockerfile_latest   # current version → getwilds/toolname:latest
+├── CVEs_*.md           # auto-generated vulnerability reports
+└── README.md           # tool documentation (required)
+template/
+├── Dockerfile_template # reference Dockerfile for new images
+└── README.md           # reference README for new images
+amd64_only_tools.txt    # tools that cannot build for linux/arm64
+Makefile                # local dev commands
+```
+
+## Dockerfile Requirements
+
+Every Dockerfile **must** include:
+
+1. **OCI metadata labels** — title, description, version, authors (`wilds@fredhutch.org`), source URL, MIT license
+2. **Shell config** — `SHELL ["/bin/bash", "-o", "pipefail", "-c"]`
+3. **Pinned versions** — use `apt-cache policy` for system packages; never use `latest` in downloads
+4. **Smoke test** — a `RUN` command verifying the install (e.g., `tool --version`)
+5. **Cleanup** — `rm -rf /var/lib/apt/lists/*`, `mamba clean -afy`, remove tarballs, etc.
+
+Common base images: `ubuntu:24.04`, `condaforge/miniforge3`, `bioconductor/bioconductor_docker:RELEASE_3_*`, `python:3.x-slim`.
+
+Target image size: a few hundred MB, max 2GB. One primary tool per image (one or two closely related companion tools are acceptable when commonly used together in workflows).
+
+## Linting and Building
+
+```bash
+make lint IMAGE=toolname        # hadolint
+make build_amd64 IMAGE=toolname # build for AMD64
+make build IMAGE=toolname       # build both architectures
+make validate IMAGE=toolname    # lint + build both
+make clean IMAGE=toolname       # remove built images
+```
+
+ARM64 builds automatically skip tools listed in `amd64_only_tools.txt`.
+
+## CI/CD
+
+- **docker-update.yml** — builds/publishes to DockerHub + GHCR on push to main
+- **dockerfile-linting.yml** — runs hadolint on PRs
+- **docker-scout.yml** — monthly security scans, auto-generates CVE reports
+
+## Commit and PR Conventions
+
+- Imperative mood: "Add samtools image", "Update GATK to v4.5", "Fix hadolint warning in picard"
+- PR titles: `Add [Tool] Docker image (vX.Y.Z)` or `Update [Tool] to vX.Y.Z`
+- Tag reviewers: @emjbishop or @tefirman
+
+## README Standards
+
+Each tool README needs: description and official docs link, available versions table, platform availability, Docker and Apptainer pull commands, usage examples, installed components list, security/CVE info, and contributing link.
+
+## Agent Skills
+
+Reusable task-specific instructions live in [.agents/skills/](.agents/skills/). Each `SKILL.md` is a self-contained recipe an agent can follow:
+
+- `new-image` — create a new Docker image for a bioinformatics tool
+- `update-image` — update an existing image to a new version
+- `fix-cves` — identify and remediate CVEs in an existing image
+- `pr-description` — draft a PR description from the current branch

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ Defined in `.github/workflows/dockerfile-linting.yml`, this workflow:
 - Automatically lints Dockerfiles for best practices and security issues
 - Ensures consistent formatting and optimization across all images
 
+## AI Disclosure
+
+We occasionally use large language models to assist with creating and updating Docker images, and contributors are welcome to do the same. All AI-generated code must go through the same linting, building, and human review process as any other contribution.
+
+To make AI assistance more consistent with project conventions, the repository ships an [`AGENTS.md`](AGENTS.md) project-context file (following the vendor-neutral [agents.md](https://agents.md/) convention) and a set of reusable task recipes under [`.agents/skills/`](.agents/skills/):
+
+- `new-image` — create a new Docker image for a bioinformatics tool
+- `update-image` — update an existing image to a new version
+- `fix-cves` — identify and remediate CVEs in an existing image
+- `pr-description` — draft a PR description from the current branch
+
+Tools that follow the AGENTS.md convention (OpenCode, Claude Code, and others) discover these files automatically. Use of these tools is optional and does not replace the testing and review requirements described in the [Contributing Guidelines](.github/CONTRIBUTING.md).
+
 ## Contributing
 
 We welcome contributions to improve and expand the WILDS Docker Library!

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"]
+}


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: vendor-neutral AI agent scaffolding (AGENTS.md + reusable SKILL.md recipes)

## Description

Introduces vendor-neutral AI coding agent context and reusable task recipes to the repo, following the [AGENTS.md](https://agents.md/) convention so any agent tool (OpenCode, Claude Code, etc.) can pick them up.

Adds:

- `AGENTS.md`: project overview, repo structure, Dockerfile requirements, linting/build commands, CI/CD notes, and PR conventions.
- `opencode.json`: minimal OpenCode config pointing at `AGENTS.md`.
- `.agents/skills/`: four self-contained `SKILL.md` recipes:
  - `new-image`: scaffold a new Docker image for a bioinformatics tool
  - `update-image`: update an existing image to a new version
  - `fix-cves`: identify and remediate CVEs in an existing image
  - `pr-description`: draft a PR description from the current branch

Also updates existing documentation to reference the new files:

- `README.md`: new "AI Disclosure" section pointing to `AGENTS.md` and `.agents/skills/`, noting that use of these tools is optional and the existing human-review requirement still applies.
- `.github/CONTRIBUTING.md`: new "AI-Assisted Development" subsection enumerating the four skills and explaining how AGENTS.md-aware tools discover them.

Also adds `.DS_Store` to `.gitignore`.

No Dockerfile or image code is changed by this PR.

## Testing

Documentation and agent-config changes only — no Dockerfile behavior is affected, so no build or lint run was required. The skill recipes are adapted from existing files that have been exercised during previous image development.