### PR TITLE
Adding initial version of CellBender WILDS Docker image

### DIFF
--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-06-24 02:39:03 PST
+Report generated on 2026-06-24 18:49:34 PST
 
 ## Platform Coverage
 

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-06-24 21:46:20 PST
+Report generated on 2026-06-24 23:11:58 PST
 
 ## Platform Coverage
 
@@ -10,11 +10,11 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 | Severity | Count |
 |----------|-------|
-| 🔴 Critical | 3 |
-| 🟠 High | 15 |
-| 🟡 Medium | 23 |
-| 🟢 Low | 147 |
-| ⚪ Unknown | 12 |
+| 🔴 Critical | 1 |
+| 🟠 High | 3 |
+| 🟡 Medium | 8 |
+| 🟢 Low | 145 |
+| ⚪ Unknown | 24 |
 
 ## 🐳 Base Image
 
@@ -35,8 +35,8 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target             │  getwilds/cellbender:0.3.2-amd64  │    3C    15H    23M   147L    12?  
-   digest           │  90a9e7944275                             │                                    
+Target             │  getwilds/cellbender:0.3.2-amd64  │    1C     3H     8M   145L    24?  
+   digest           │  b64dfb169352                             │                                    
  Base image         │  python:3.11-slim                         │    1C     3H     7M    26L     2?  
  Updated base image │  python:3.14-slim                         │    1C     2H     3M    25L     2?  
                     │                                           │           -1     -4     -1         

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,20 +1,49 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-06-24 18:49:34 PST
+Report generated on 2026-06-24 21:46:20 PST
 
 ## Platform Coverage
 
 This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
 
-## ⚠️ Scan Skipped - Image Too Large
+## 📊 Vulnerability Summary
 
-Docker Scout scan was skipped for this image because it exceeds the size limit.
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 3 |
+| 🟠 High | 15 |
+| 🟡 Medium | 23 |
+| 🟢 Low | 147 |
+| ⚪ Unknown | 12 |
 
-**Image size:** 3.0 GB
-**Size limit:** 3.0 GB
+## 🐳 Base Image
 
-Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
+**Image:** `python:3.11-slim`
 
-```bash
-docker scout quickview getwilds/cellbender:0.3.2-amd64 --platform linux/amd64
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 1 |
+| 🟠 High | 3 |
+| 🟡 Medium | 7 |
+| 🟢 Low | 26 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.14-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/cellbender:0.3.2-amd64  │    3C    15H    23M   147L    12?  
+   digest           │  90a9e7944275                             │                                    
+ Base image         │  python:3.11-slim                         │    1C     3H     7M    26L     2?  
+ Updated base image │  python:3.14-slim                         │    1C     2H     3M    25L     2?  
+                    │                                           │           -1     -4     -1         
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/cellbender:0.3.2-amd64
+    View base image update recommendations → docker scout recommendations getwilds/cellbender:0.3.2-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/cellbender:0.3.2-amd64 --org <organization>
 ```
+</details>

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,0 +1,20 @@
+# Vulnerability Report for getwilds/cellbender:0.3.2
+
+Report generated on 2026-06-24 02:39:03 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## ⚠️ Scan Skipped - Image Too Large
+
+Docker Scout scan was skipped for this image because it exceeds the size limit.
+
+**Image size:** 3.0 GB
+**Size limit:** 3.0 GB
+
+Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
+
+```bash
+docker scout quickview getwilds/cellbender:0.3.2-amd64 --platform linux/amd64
+```

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-06-24 03:11:33 PST
+Report generated on 2026-06-24 19:24:09 PST
 
 ## Platform Coverage
 

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,20 +1,49 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-06-24 19:24:09 PST
+Report generated on 2026-06-24 22:16:13 PST
 
 ## Platform Coverage
 
 This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
 
-## ⚠️ Scan Skipped - Image Too Large
+## 📊 Vulnerability Summary
 
-Docker Scout scan was skipped for this image because it exceeds the size limit.
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 3 |
+| 🟠 High | 15 |
+| 🟡 Medium | 23 |
+| 🟢 Low | 147 |
+| ⚪ Unknown | 12 |
 
-**Image size:** 3.0 GB
-**Size limit:** 3.0 GB
+## 🐳 Base Image
 
-Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
+**Image:** `python:3.11-slim`
 
-```bash
-docker scout quickview getwilds/cellbender:latest-amd64 --platform linux/amd64
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 1 |
+| 🟠 High | 3 |
+| 🟡 Medium | 7 |
+| 🟢 Low | 26 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.14-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/cellbender:latest-amd64  │    3C    15H    23M   147L    12?  
+   digest           │  7affced19e2e                              │                                    
+ Base image         │  python:3.11-slim                          │    1C     3H     7M    26L     2?  
+ Updated base image │  python:3.14-slim                          │    1C     2H     3M    25L     2?  
+                    │                                            │           -1     -4     -1         
+
+What's next:
+    View vulnerabilities → docker scout cves getwilds/cellbender:latest-amd64
+    View base image update recommendations → docker scout recommendations getwilds/cellbender:latest-amd64
+    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/cellbender:latest-amd64 --org <organization>
 ```
+</details>

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,0 +1,20 @@
+# Vulnerability Report for getwilds/cellbender:latest
+
+Report generated on 2026-06-24 03:11:33 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## ⚠️ Scan Skipped - Image Too Large
+
+Docker Scout scan was skipped for this image because it exceeds the size limit.
+
+**Image size:** 3.0 GB
+**Size limit:** 3.0 GB
+
+Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
+
+```bash
+docker scout quickview getwilds/cellbender:latest-amd64 --platform linux/amd64
+```

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-06-24 22:16:13 PST
+Report generated on 2026-06-24 23:45:28 PST
 
 ## Platform Coverage
 
@@ -10,11 +10,11 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 | Severity | Count |
 |----------|-------|
-| 🔴 Critical | 3 |
-| 🟠 High | 15 |
-| 🟡 Medium | 23 |
-| 🟢 Low | 147 |
-| ⚪ Unknown | 12 |
+| 🔴 Critical | 1 |
+| 🟠 High | 3 |
+| 🟡 Medium | 8 |
+| 🟢 Low | 145 |
+| ⚪ Unknown | 24 |
 
 ## 🐳 Base Image
 
@@ -35,8 +35,8 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target             │  getwilds/cellbender:latest-amd64  │    3C    15H    23M   147L    12?  
-   digest           │  7affced19e2e                              │                                    
+Target             │  getwilds/cellbender:latest-amd64  │    1C     3H     8M   145L    24?  
+   digest           │  5e99ff7a1fd0                              │                                    
  Base image         │  python:3.11-slim                          │    1C     3H     7M    26L     2?  
  Updated base image │  python:3.14-slim                          │    1C     2H     3M    25L     2?  
                     │                                            │           -1     -4     -1         

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -24,5 +24,5 @@ RUN apt-get update \
   gcc="${GCC_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir torch==2.0.1 cellbender==0.3.2 \
+RUN pip install --no-cache-dir torch==2.0.1 "numpy<2.0" cellbender==0.3.2 \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -18,11 +18,13 @@ RUN apt-get update \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
+  git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir torch==2.0.1 "numpy<2.0" cellbender==0.3.2 \
+RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@master \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -26,5 +26,5 @@ RUN apt-get update \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@master \
+RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -24,5 +24,5 @@ RUN apt-get update \
   gcc="${GCC_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir cellbender==0.3.2 \
+RUN pip install --no-cache-dir torch==2.0.1 cellbender==0.3.2 \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="cellbender"
+LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="0.3.2"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# HDF5 libraries required by the PyTables dependency (tables)
+RUN apt-get update \
+  && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
+  && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
+  && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  libhdf5-dev="${LIBHDF5_VERSION}" \
+  pkg-config="${PKG_CONFIG_VERSION}" \
+  gcc="${GCC_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir cellbender==0.3.2 \
+  && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -24,5 +24,5 @@ RUN apt-get update \
   gcc="${GCC_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir torch==2.0.1 cellbender==0.3.2 \
+RUN pip install --no-cache-dir torch==2.0.1 "numpy<2.0" cellbender==0.3.2 \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -18,11 +18,13 @@ RUN apt-get update \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
+  git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir torch==2.0.1 "numpy<2.0" cellbender==0.3.2 \
+RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@master \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="cellbender"
+LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# HDF5 libraries required by the PyTables dependency (tables)
+RUN apt-get update \
+  && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
+  && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
+  && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  libhdf5-dev="${LIBHDF5_VERSION}" \
+  pkg-config="${PKG_CONFIG_VERSION}" \
+  gcc="${GCC_VERSION}" \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir cellbender==0.3.2 \
+  && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -26,5 +26,5 @@ RUN apt-get update \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@master \
+RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -24,5 +24,5 @@ RUN apt-get update \
   gcc="${GCC_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir cellbender==0.3.2 \
+RUN pip install --no-cache-dir torch==2.0.1 cellbender==0.3.2 \
   && cellbender --version

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -9,7 +9,7 @@ This directory contains Docker images for CellBender, a tool for removing techni
 
 ## Image Details
 
-These Docker images are built from Python 3.12 slim and include:
+These Docker images are built from Python 3.11 slim and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
 - PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
@@ -105,7 +105,7 @@ CellBender produces an `.h5` output file containing corrected counts and latent 
 
 The Dockerfile follows these main steps:
 
-1. Uses Python 3.12 slim as the base image
+1. Uses Python 3.11 slim as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
 4. Installs CellBender v0.3.2 via pip, which pulls in PyTorch (CUDA-enabled) and all other dependencies

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -17,7 +17,7 @@ These Docker images are built from Python 3.11 slim and include:
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.
 
-> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, CellBender is currently installed from the upstream master branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The master branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
+> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, CellBender is currently installed from the upstream main branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The master branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
 
 ## Citation
 

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -12,11 +12,12 @@ This directory contains Docker images for CellBender, a tool for removing techni
 These Docker images are built from Python 3.11 slim and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch v2.0.1 (CUDA-enabled): Pinned to 2.0.1 to avoid a `torch.save` weakref serialization bug present in later PyTorch versions that causes CellBender checkpointing to fail; provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
-- NumPy <2.0: Pinned to the 1.x series to match the ABI that PyTorch 2.0.1 was compiled against; NumPy 2.x breaks torch tensor-to-array conversion at runtime
+- PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.
+
+> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, CellBender is currently installed from the upstream master branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The master branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
 
 ## Citation
 
@@ -109,7 +110,7 @@ The Dockerfile follows these main steps:
 1. Uses Python 3.11 slim as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Installs PyTorch v2.0.1 and CellBender v0.3.2 via pip with pinned torch version to avoid a checkpoint serialization bug in later PyTorch releases
+4. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
 5. Runs `cellbender --version` as a smoke test to verify the install
 6. Uses `--no-cache-dir` and apt list cleanup to minimize image size
 

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -12,7 +12,7 @@ This directory contains Docker images for CellBender, a tool for removing techni
 These Docker images are built from Python 3.11 slim and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- PyTorch v2.0.1 (CUDA-enabled): Pinned to 2.0.1 to avoid a `torch.save` weakref serialization bug present in later PyTorch versions that causes CellBender checkpointing to fail; provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.
@@ -108,7 +108,7 @@ The Dockerfile follows these main steps:
 1. Uses Python 3.11 slim as the base image
 2. Adds metadata labels for documentation and attribution
 3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Installs CellBender v0.3.2 via pip, which pulls in PyTorch (CUDA-enabled) and all other dependencies
+4. Installs PyTorch v2.0.1 and CellBender v0.3.2 via pip with pinned torch version to avoid a checkpoint serialization bug in later PyTorch releases
 5. Runs `cellbender --version` as a smoke test to verify the install
 6. Uses `--no-cache-dir` and apt list cleanup to minimize image size
 

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -13,6 +13,7 @@ These Docker images are built from Python 3.11 slim and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
 - PyTorch v2.0.1 (CUDA-enabled): Pinned to 2.0.1 to avoid a `torch.save` weakref serialization bug present in later PyTorch versions that causes CellBender checkpointing to fail; provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- NumPy <2.0: Pinned to the 1.x series to match the ABI that PyTorch 2.0.1 was compiled against; NumPy 2.x breaks torch tensor-to-array conversion at runtime
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -1,0 +1,125 @@
+# CellBender
+
+This directory contains Docker images for CellBender, a tool for removing technical artifacts (ambient RNA and barcode swapping) from droplet-based single-cell and single-nucleus RNA sequencing count matrices.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_latest.md) )
+- `0.3.2` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_0.3.2) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_0.3.2.md) )
+
+## Image Details
+
+These Docker images are built from Python 3.12 slim and include:
+
+- CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
+- PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- PyTables/HDF5: Required for reading and writing `.h5` count matrix files
+
+The images are designed to be minimal and focused on CellBender with its essential dependencies.
+
+## Citation
+
+If you use CellBender in your research, please cite the original authors:
+
+```
+Fleming, S.J., Chaffin, M.D., Arduini, A., Akkad, A.D., Banks, E., Marioni, J.C.,
+Philippakis, A.A., Ellinor, P.T., & Babadi, M. (2023). Unsupervised removal of
+systematic background noise from droplet-based single-cell experiments using CellBender.
+Nature Methods, 20, 1323-1335. https://doi.org/10.1038/s41592-023-01943-7
+```
+
+**Tool homepage:** https://github.com/broadinstitute/CellBender
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/cellbender:latest
+
+# Or pull a specific version
+docker pull getwilds/cellbender:0.3.2
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/cellbender:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/cellbender:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/cellbender:0.3.2
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/cellbender:latest
+```
+
+### Example Commands
+
+```bash
+# Remove background from a CellRanger output directory (CPU)
+docker run --rm -v /path/to/data:/data getwilds/cellbender:latest \
+  cellbender remove-background \
+  --input /data/raw_feature_bc_matrix.h5 \
+  --output /data/cellbender_output.h5
+
+# Remove background with GPU acceleration (requires NVIDIA runtime)
+docker run --rm --gpus all -v /path/to/data:/data getwilds/cellbender:latest \
+  cellbender remove-background \
+  --input /data/raw_feature_bc_matrix.h5 \
+  --output /data/cellbender_output.h5 \
+  --cuda
+
+# Remove background with custom parameters (expected cells and droplets)
+docker run --rm -v /path/to/data:/data getwilds/cellbender:latest \
+  cellbender remove-background \
+  --input /data/raw_feature_bc_matrix.h5 \
+  --output /data/cellbender_output.h5 \
+  --expected-cells 5000 \
+  --total-droplets-included 15000 \
+  --fpr 0.01 \
+  --epochs 150
+
+# Using Apptainer with a local SIF file
+apptainer run --bind /path/to/data:/data cellbender_latest.sif \
+  cellbender remove-background \
+  --input /data/raw_feature_bc_matrix.h5 \
+  --output /data/cellbender_output.h5
+```
+
+## Important Notes
+
+### GPU support
+
+The PyTorch included in this image is built with CUDA support. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
+
+### Output files
+
+CellBender produces an `.h5` output file containing corrected counts and latent variables. The filtered count matrix can be loaded directly into Scanpy (`sc.read_10x_h5`) or converted for use in Seurat.
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Python 3.12 slim as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
+4. Installs CellBender v0.3.2 via pip, which pulls in PyTorch (CUDA-enabled) and all other dependencies
+5. Runs `cellbender --version` as a smoke test to verify the install
+6. Uses `--no-cache-dir` and apt list cleanup to minimize image size
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a Docker image for [CellBender](https://github.com/broadinstitute/CellBender) v0.3.2, a tool for removing ambient RNA and barcode swapping artifacts from droplet-based scRNA-seq and snRNA-seq count matrices using a deep generative model (published in Nature Methods 2023).

- **Base image:** `python:3.11-slim`
- **Installation method:** pip (from GitHub main branch, see note below)
- **Key dependencies:** PyTorch (CUDA-enabled for optional GPU acceleration), PyTables/HDF5 for `.h5` file I/O
- Compatible with both `linux/amd64` and `linux/arm64`

**Note on version pinning exception:** CellBender is installed directly from the upstream `main` branch rather than a pinned PyPI release. The v0.3.2 PyPI release has a `torch.save` checkpoint serialization bug ([broadinstitute/CellBender#444](https://github.com/broadinstitute/CellBender/issues/444)) that causes runs to fail in practice. The fix is merged on `main` but not yet in a release. This image will be updated to pin a specific version once v0.3.3 is published.

## Testing

**How did you test these changes?**

Ran `make lint IMAGE=cellbender` with hadolint v2.12.0 and validated end-to-end by running a WDL workflow against the built image.

**Did the tests pass?**

Yes — lint passed clean and the WDL workflow completed successfully.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

PyTorch is installed with CUDA support (the default pip wheel) so users can take advantage of GPU acceleration via `--cuda` on GPU-enabled machines. CellBender falls back to CPU automatically when no GPU is detected.