### PR TITLE
Switching `cellbender` to an NVIDIA base image

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,7 +109,7 @@ wilds-docker-library/
 
 **Your Dockerfile must include:**
 
-- **Appropriate base image**: Choose the minimal base that supports your tool (Ubuntu, Miniforge, Bioconductor, etc.)
+- **Appropriate base image**: Choose the minimal base that supports your tool (Ubuntu, Miniforge, Bioconductor, etc.). GPU-centric tools that require CUDA should use `nvidia/cuda:X.Y.Z-runtime-ubuntuXX.XX`.
 - **Complete metadata labels**: All required OCI labels with accurate information
 - **Shell configuration**: `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` for better error handling
 - **Pinned versions**: All dependencies should use explicit versions for reproducibility
@@ -154,6 +154,7 @@ LABEL org.opencontainers.image.licenses=MIT
 - Our CI/CD automatically attempts multi-platform builds
 - If your tool has platform restrictions, document them clearly in the README
 - See existing AMD64-only images (BWA, DESeq2, HISAT2, etc.) for examples
+- Tools that use PyTorch CUDA wheels must be added to `amd64_only_tools.txt` — those wheels are not available for ARM64
 
 **Tool Focus:**
 - One primary tool per image (maximum 1-2 closely related tools)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Every Dockerfile **must** include:
 4. **Smoke test** — a `RUN` command verifying the install (e.g., `tool --version`)
 5. **Cleanup** — `rm -rf /var/lib/apt/lists/*`, `mamba clean -afy`, remove tarballs, etc.
 
-Common base images: `ubuntu:24.04`, `condaforge/miniforge3`, `bioconductor/bioconductor_docker:RELEASE_3_*`, `python:3.x-slim`.
+Common base images: `ubuntu:24.04`, `condaforge/miniforge3`, `bioconductor/bioconductor_docker:RELEASE_3_*`, `python:3.x-slim`. GPU-centric tools that require CUDA should use `nvidia/cuda:X.Y.Z-runtime-ubuntuXX.XX`; if they use PyTorch CUDA wheels, also add them to `amd64_only_tools.txt` (those wheels are not available for ARM64).
 
 Target image size: a few hundred MB, max 2GB. One primary tool per image (one or two closely related companion tools are acceptable when commonly used together in workflows).
 

--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -1,5 +1,6 @@
 bwa
 clair3
+cellbender
 cellranger
 colabfold
 deseq2

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-07-02 06:31:00 PST
+Report generated on 2026-07-02 14:59:16 PST
 
 ## Platform Coverage
 

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-07-01 18:58:41 PST
+Report generated on 2026-07-02 05:38:27 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 4.6 GB
+**Image size:** 4.5 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-07-02 14:59:16 PST
+Report generated on 2026-07-02 17:44:36 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 4.5 GB
+**Image size:** 5.0 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-07-02 05:38:27 PST
+Report generated on 2026-07-02 06:31:00 PST
 
 ## Platform Coverage
 

--- a/cellbender/CVEs_0.3.2.md
+++ b/cellbender/CVEs_0.3.2.md
@@ -1,49 +1,20 @@
 # Vulnerability Report for getwilds/cellbender:0.3.2
 
-Report generated on 2026-06-30 17:39:53 PST
+Report generated on 2026-07-01 18:58:41 PST
 
 ## Platform Coverage
 
 This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
 
-## 📊 Vulnerability Summary
+## ⚠️ Scan Skipped - Image Too Large
 
-| Severity | Count |
-|----------|-------|
-| 🔴 Critical | 1 |
-| 🟠 High | 3 |
-| 🟡 Medium | 8 |
-| 🟢 Low | 144 |
-| ⚪ Unknown | 17 |
+Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-## 🐳 Base Image
+**Image size:** 4.6 GB
+**Size limit:** 3.0 GB
 
-**Image:** `python:3.11-slim`
+Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
 
-| Severity | Count |
-|----------|-------|
-| 🔴 Critical | 1 |
-| 🟠 High | 3 |
-| 🟡 Medium | 7 |
-| 🟢 Low | 26 |
-
-## 🔄 Recommendations
-
-**Updated base image:** `python:3.14-slim`
-
-<details>
-<summary>📋 Raw Docker Scout Output</summary>
-
-```text
-Target             │  getwilds/cellbender:0.3.2-amd64  │    1C     3H     8M   144L    17?  
-   digest           │  8c0190b65840                             │                                    
- Base image         │  python:3.11-slim                         │    1C     3H     7M    26L     2?  
- Updated base image │  python:3.14-slim                         │    1C     2H     3M    25L     2?  
-                    │                                           │           -1     -4     -1         
-
-What's next:
-    View vulnerabilities → docker scout cves getwilds/cellbender:0.3.2-amd64
-    View base image update recommendations → docker scout recommendations getwilds/cellbender:0.3.2-amd64
-    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/cellbender:0.3.2-amd64 --org <organization>
+```bash
+docker scout quickview getwilds/cellbender:0.3.2 --platform linux/amd64
 ```
-</details>

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,49 +1,20 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-06-30 18:13:38 PST
+Report generated on 2026-07-01 19:08:50 PST
 
 ## Platform Coverage
 
 This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
 
-## 📊 Vulnerability Summary
+## ⚠️ Scan Skipped - Image Too Large
 
-| Severity | Count |
-|----------|-------|
-| 🔴 Critical | 1 |
-| 🟠 High | 3 |
-| 🟡 Medium | 8 |
-| 🟢 Low | 144 |
-| ⚪ Unknown | 17 |
+Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-## 🐳 Base Image
+**Image size:** 4.5 GB
+**Size limit:** 3.0 GB
 
-**Image:** `python:3.11-slim`
+Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:
 
-| Severity | Count |
-|----------|-------|
-| 🔴 Critical | 1 |
-| 🟠 High | 3 |
-| 🟡 Medium | 7 |
-| 🟢 Low | 26 |
-
-## 🔄 Recommendations
-
-**Updated base image:** `python:3.14-slim`
-
-<details>
-<summary>📋 Raw Docker Scout Output</summary>
-
-```text
-Target             │  getwilds/cellbender:latest-amd64  │    1C     3H     8M   144L    17?  
-   digest           │  fa4d7aa5747c                              │                                    
- Base image         │  python:3.11-slim                          │    1C     3H     7M    26L     2?  
- Updated base image │  python:3.14-slim                          │    1C     2H     3M    25L     2?  
-                    │                                            │           -1     -4     -1         
-
-What's next:
-    View vulnerabilities → docker scout cves getwilds/cellbender:latest-amd64
-    View base image update recommendations → docker scout recommendations getwilds/cellbender:latest-amd64
-    Include policy results in your quickview by supplying an organization → docker scout quickview getwilds/cellbender:latest-amd64 --org <organization>
+```bash
+docker scout quickview getwilds/cellbender:latest --platform linux/amd64
 ```
-</details>

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-07-02 15:08:04 PST
+Report generated on 2026-07-02 17:54:59 PST
 
 ## Platform Coverage
 
@@ -10,7 +10,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 Docker Scout scan was skipped for this image because it exceeds the size limit.
 
-**Image size:** 4.5 GB
+**Image size:** 5.0 GB
 **Size limit:** 3.0 GB
 
 Large images can cause timeouts and resource exhaustion in CI/CD environments. If you need a vulnerability scan for this image, please run it manually:

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-07-01 19:08:50 PST
+Report generated on 2026-07-02 05:47:36 PST
 
 ## Platform Coverage
 

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-07-02 06:41:42 PST
+Report generated on 2026-07-02 15:08:04 PST
 
 ## Platform Coverage
 

--- a/cellbender/CVEs_latest.md
+++ b/cellbender/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/cellbender:latest
 
-Report generated on 2026-07-02 05:47:36 PST
+Report generated on 2026-07-02 06:41:42 PST
 
 ## Platform Coverage
 

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+FROM python:3.11-slim
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -13,29 +13,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# HDF5 libraries required by the PyTables dependency (tables)
 RUN apt-get update \
-  && PYTHON311_VERSION=$(apt-cache policy python3.11 | grep Candidate | awk '{print $2}') \
-  && PYTHON311_PIP_VERSION=$(apt-cache policy python3.11-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
   && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
-  python3.11="${PYTHON311_VERSION}" \
-  python3.11-pip="${PYTHON311_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-# Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
-# GTX 1080 Ti at CC 6.1) before installing CellBender to prevent pip from pulling
-# in a CUDA 12.x build as a transitive dependency.
-RUN python3.11 -m pip install --no-cache-dir \
-  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
-  && python3.11 -m pip install --no-cache-dir \
-  cellbender==0.3.2 \
+RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version
-
-WORKDIR /data

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -13,18 +13,26 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# HDF5 libraries required by the PyTables dependency (tables)
 RUN apt-get update \
+  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
+  && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
-  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
+  python3="${PYTHON3_VERSION}" \
+  python3-pip="${PYTHON3_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
-  git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
+# Install PyTorch with pinned CUDA 12.6 wheels before CellBender so GPU behavior
+# is consistent regardless of what CUDA version the host has installed.
+RUN pip install --no-cache-dir --break-system-packages \
+  torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu126 \
+  && pip install --no-cache-dir --break-system-packages \
+  cellbender==0.3.2 \
   && cellbender --version
+
+WORKDIR /data

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -13,18 +13,29 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# HDF5 libraries required by the PyTables dependency (tables)
 RUN apt-get update \
+  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
+  && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
   && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
+  python3="${PYTHON3_VERSION}" \
+  python3-pip="${PYTHON3_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
+# Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
+# older GPUs like GTX 1080 Ti at CC 6.1) before installing CellBender to prevent
+# pip from pulling in a CUDA 12.x build as a transitive dependency.
+RUN pip3 install --no-cache-dir \
+  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  && pip3 install --no-cache-dir \
+  git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version
+
+WORKDIR /data

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -12,6 +12,7 @@ LABEL org.opencontainers.image.licenses=MIT
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/usr/local/bin:${PATH}"
 
 RUN apt-get update \
   && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
@@ -32,8 +33,12 @@ RUN apt-get update \
 # Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
 # older GPUs like GTX 1080 Ti at CC 6.1) before installing CellBender to prevent
 # pip from pulling in a CUDA 12.x build as a transitive dependency.
+# pip must be upgraded before installing CellBender: Ubuntu 22.04 ships pip 22.0.2,
+# which fails to register entry points when the package name resolves to "UNKNOWN"
+# (caused by pip's shallow git clone omitting tags used by setuptools-git-versioning).
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  && pip3 install --no-cache-dir --upgrade pip \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -37,7 +37,7 @@ RUN apt-get update \
 # which fails to register entry points when the package name resolves to "UNKNOWN"
 # (caused by pip's shallow git clone omitting tags used by setuptools-git-versioning).
 RUN pip3 install --no-cache-dir \
-  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  torch==2.2.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
   && pip3 install --no-cache-dir "pip==26.1.2" \
   && pip3 install --no-cache-dir "numpy==1.26.4" "pyro-ppl==1.9.1" \
   && pip3 install --no-cache-dir \

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -14,24 +14,27 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
-  && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
+  && PYTHON311_VERSION=$(apt-cache policy python3.11 | grep Candidate | awk '{print $2}') \
+  && PYTHON311_PIP_VERSION=$(apt-cache policy python3.11-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
+  && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
-  python3="${PYTHON3_VERSION}" \
-  python3-pip="${PYTHON3_PIP_VERSION}" \
+  python3.11="${PYTHON311_VERSION}" \
+  python3.11-pip="${PYTHON311_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
+  git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-# Install PyTorch with pinned CUDA 12.6 wheels before CellBender so GPU behavior
-# is consistent regardless of what CUDA version the host has installed.
-RUN pip install --no-cache-dir --break-system-packages \
-  torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu126 \
-  && pip install --no-cache-dir --break-system-packages \
+# Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
+# GTX 1080 Ti at CC 6.1) before installing CellBender to prevent pip from pulling
+# in a CUDA 12.x build as a transitive dependency.
+RUN python3.11 -m pip install --no-cache-dir \
+  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  && python3.11 -m pip install --no-cache-dir \
   cellbender==0.3.2 \
   && cellbender --version
 

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -38,7 +38,7 @@ RUN apt-get update \
 # (caused by pip's shallow git clone omitting tags used by setuptools-git-versioning).
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
-  && pip3 install --no-cache-dir --upgrade pip \
+  && pip3 install --no-cache-dir "pip==26.1.2" \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -39,6 +39,7 @@ RUN apt-get update \
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
   && pip3 install --no-cache-dir "pip==26.1.2" \
+  && pip3 install --no-cache-dir "numpy==1.26.4" \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_0.3.2
+++ b/cellbender/Dockerfile_0.3.2
@@ -39,7 +39,7 @@ RUN apt-get update \
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
   && pip3 install --no-cache-dir "pip==26.1.2" \
-  && pip3 install --no-cache-dir "numpy==1.26.4" \
+  && pip3 install --no-cache-dir "numpy==1.26.4" "pyro-ppl==1.9.1" \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -14,26 +14,27 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
-  && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
+  && PYTHON311_VERSION=$(apt-cache policy python3.11 | grep Candidate | awk '{print $2}') \
+  && PYTHON311_PIP_VERSION=$(apt-cache policy python3.11-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
   && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
-  python3="${PYTHON3_VERSION}" \
-  python3-pip="${PYTHON3_PIP_VERSION}" \
+  python3.11="${PYTHON311_VERSION}" \
+  python3.11-pip="${PYTHON311_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-# Install PyTorch with pinned CUDA 12.6 wheels before CellBender so GPU behavior
-# is consistent regardless of what CUDA version the host has installed.
-RUN pip install --no-cache-dir --break-system-packages \
-  torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu126 \
-  && pip install --no-cache-dir --break-system-packages \
+# Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
+# GTX 1080 Ti at CC 6.1) before installing CellBender to prevent pip from pulling
+# in a CUDA 12.x build as a transitive dependency.
+RUN python3.11 -m pip install --no-cache-dir \
+  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  && python3.11 -m pip install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version
 

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -13,18 +13,29 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# HDF5 libraries required by the PyTables dependency (tables)
 RUN apt-get update \
+  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
+  && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
   && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
+  python3="${PYTHON3_VERSION}" \
+  python3-pip="${PYTHON3_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
+# Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
+# older GPUs like GTX 1080 Ti at CC 6.1) before installing CellBender to prevent
+# pip from pulling in a CUDA 12.x build as a transitive dependency.
+RUN pip3 install --no-cache-dir \
+  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  && pip3 install --no-cache-dir \
+  git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version
+
+WORKDIR /data

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -12,6 +12,7 @@ LABEL org.opencontainers.image.licenses=MIT
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/usr/local/bin:${PATH}"
 
 RUN apt-get update \
   && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
@@ -32,8 +33,12 @@ RUN apt-get update \
 # Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
 # older GPUs like GTX 1080 Ti at CC 6.1) before installing CellBender to prevent
 # pip from pulling in a CUDA 12.x build as a transitive dependency.
+# pip must be upgraded before installing CellBender: Ubuntu 22.04 ships pip 22.0.2,
+# which fails to register entry points when the package name resolves to "UNKNOWN"
+# (caused by pip's shallow git clone omitting tags used by setuptools-git-versioning).
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  && pip3 install --no-cache-dir --upgrade pip \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+FROM python:3.11-slim
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -13,29 +13,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# HDF5 libraries required by the PyTables dependency (tables)
 RUN apt-get update \
-  && PYTHON311_VERSION=$(apt-cache policy python3.11 | grep Candidate | awk '{print $2}') \
-  && PYTHON311_PIP_VERSION=$(apt-cache policy python3.11-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
   && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
-  python3.11="${PYTHON311_VERSION}" \
-  python3.11-pip="${PYTHON311_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-# Pin PyTorch to a CUDA 11.8 wheel (supports Compute Capability >= 3.5, including
-# GTX 1080 Ti at CC 6.1) before installing CellBender to prevent pip from pulling
-# in a CUDA 12.x build as a transitive dependency.
-RUN python3.11 -m pip install --no-cache-dir \
-  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
-  && python3.11 -m pip install --no-cache-dir \
-  git+https://github.com/broadinstitute/CellBender.git@main \
+RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version
-
-WORKDIR /data

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM nvidia/cuda:12.6.3-runtime-ubuntu24.04
 
 LABEL org.opencontainers.image.title="cellbender"
 LABEL org.opencontainers.image.description="Docker image for CellBender in Fred Hutch OCDO's WILDS"
@@ -13,18 +13,28 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# HDF5 libraries required by the PyTables dependency (tables)
 RUN apt-get update \
+  && PYTHON3_VERSION=$(apt-cache policy python3 | grep Candidate | awk '{print $2}') \
+  && PYTHON3_PIP_VERSION=$(apt-cache policy python3-pip | grep Candidate | awk '{print $2}') \
   && LIBHDF5_VERSION=$(apt-cache policy libhdf5-dev | grep Candidate | awk '{print $2}') \
   && PKG_CONFIG_VERSION=$(apt-cache policy pkg-config | grep Candidate | awk '{print $2}') \
   && GCC_VERSION=$(apt-cache policy gcc | grep Candidate | awk '{print $2}') \
   && GIT_VERSION=$(apt-cache policy git | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
+  python3="${PYTHON3_VERSION}" \
+  python3-pip="${PYTHON3_PIP_VERSION}" \
   libhdf5-dev="${LIBHDF5_VERSION}" \
   pkg-config="${PKG_CONFIG_VERSION}" \
   gcc="${GCC_VERSION}" \
   git="${GIT_VERSION}" \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir git+https://github.com/broadinstitute/CellBender.git@main \
+# Install PyTorch with pinned CUDA 12.6 wheels before CellBender so GPU behavior
+# is consistent regardless of what CUDA version the host has installed.
+RUN pip install --no-cache-dir --break-system-packages \
+  torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu126 \
+  && pip install --no-cache-dir --break-system-packages \
+  git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version
+
+WORKDIR /data

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -37,7 +37,7 @@ RUN apt-get update \
 # which fails to register entry points when the package name resolves to "UNKNOWN"
 # (caused by pip's shallow git clone omitting tags used by setuptools-git-versioning).
 RUN pip3 install --no-cache-dir \
-  torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
+  torch==2.2.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
   && pip3 install --no-cache-dir "pip==26.1.2" \
   && pip3 install --no-cache-dir "numpy==1.26.4" "pyro-ppl==1.9.1" \
   && pip3 install --no-cache-dir \

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -38,7 +38,7 @@ RUN apt-get update \
 # (caused by pip's shallow git clone omitting tags used by setuptools-git-versioning).
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
-  && pip3 install --no-cache-dir --upgrade pip \
+  && pip3 install --no-cache-dir "pip==26.1.2" \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -39,6 +39,7 @@ RUN apt-get update \
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
   && pip3 install --no-cache-dir "pip==26.1.2" \
+  && pip3 install --no-cache-dir "numpy==1.26.4" \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/Dockerfile_latest
+++ b/cellbender/Dockerfile_latest
@@ -39,7 +39,7 @@ RUN apt-get update \
 RUN pip3 install --no-cache-dir \
   torch==2.0.1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 \
   && pip3 install --no-cache-dir "pip==26.1.2" \
-  && pip3 install --no-cache-dir "numpy==1.26.4" \
+  && pip3 install --no-cache-dir "numpy==1.26.4" "pyro-ppl==1.9.1" \
   && pip3 install --no-cache-dir \
   git+https://github.com/broadinstitute/CellBender.git@main \
   && cellbender --version

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -11,13 +11,13 @@ This directory contains Docker images for CellBender, a tool for removing techni
 
 ## Image Details
 
-These Docker images are built from the NVIDIA CUDA 12.6 runtime base image (`nvidia/cuda:12.6.3-runtime-ubuntu24.04`) and include:
+These Docker images are built from the NVIDIA CUDA 11.8 runtime base image (`nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04`) and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch 2.6.0 (CUDA 12.6): Provides consistent GPU acceleration across different host environments when run with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is detected
+- PyTorch 2.0.1 (CUDA 11.8): Provides consistent GPU acceleration across a wide range of NVIDIA hardware, including older GPUs such as the GTX 1080 Ti (Compute Capability 6.1); falls back to CPU automatically when no GPU is detected
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
-The images are designed to be minimal and focused on CellBender with its essential dependencies. Using the NVIDIA base image ensures the CUDA runtime is bundled inside the image, so GPU behavior is consistent regardless of what CUDA version is installed on the host.
+The images are designed to be minimal and focused on CellBender with its essential dependencies. Using the NVIDIA base image with a CUDA 11.8 wheel ensures the CUDA runtime is bundled inside the image and compatible with GPUs back to Compute Capability 3.5, so GPU behavior is consistent regardless of what CUDA version is installed on the host.
 
 > **Note:** As an exception to this repository's standard practice of pinning to a specific release version, the `latest` image installs CellBender from the upstream main branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The main branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
 
@@ -99,7 +99,7 @@ apptainer run --bind /path/to/data:/data cellbender_latest.sif \
 
 ### GPU support
 
-These images bundle PyTorch 2.6.0 with CUDA 12.6, so GPU behavior is consistent regardless of what CUDA version is installed on the host. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
+These images bundle PyTorch 2.0.1 with CUDA 11.8, so GPU behavior is consistent regardless of what CUDA version is installed on the host. CUDA 11.8 supports NVIDIA GPUs back to Compute Capability 3.5, including older cards such as the GTX 1080 Ti (CC 6.1). On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
 
 ### Output files
 
@@ -109,10 +109,10 @@ CellBender produces an `.h5` output file containing corrected counts and latent 
 
 The Dockerfile follows these main steps:
 
-1. Uses `nvidia/cuda:12.6.3-runtime-ubuntu24.04` as the base image to bundle the CUDA runtime
+1. Uses `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` as the base image to bundle a CUDA runtime compatible with GPUs back to Compute Capability 3.5
 2. Adds metadata labels for documentation and attribution
-3. Installs Python 3, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Installs PyTorch 2.6.0 with CUDA 12.6 wheels to ensure consistent GPU behavior across hosts
+3. Installs Python 3.11, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
+4. Installs PyTorch 2.0.1 with CUDA 11.8 wheels via `python3.11 -m pip` to prevent pip from pulling in a CUDA 12.x build as a transitive dependency
 5. Installs CellBender directly from the main branch on GitHub (for `latest`), incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release
 6. Runs `cellbender --version` as a smoke test to verify the install
 7. Uses `--no-cache-dir` and apt list cleanup to minimize image size

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -14,7 +14,8 @@ This directory contains Docker images for CellBender, a tool for removing techni
 These Docker images are built from the `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` base image and include:
 
 - CellBender (installed from the upstream main branch): Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- PyTorch 2.0.1 (CUDA 11.8): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- NumPy 1.26.4: Pinned to the 1.x series for compatibility with PyTorch 2.0.x, which predates the NumPy 2.0 ABI change
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.
@@ -112,7 +113,7 @@ The Dockerfile follows these main steps:
 1. Uses `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` as the base image, providing CUDA 11.8 libraries that support GPUs with Compute Capability >= 3.5 (including older hardware like the GTX 1080 Ti)
 2. Adds metadata labels for documentation and attribution
 3. Installs Python 3, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Pins PyTorch to a CUDA 11.8 wheel before installing CellBender to prevent pip from pulling in a CUDA 12.x build as a transitive dependency
+4. Pins PyTorch to a CUDA 11.8 wheel and NumPy to 1.26.4 before installing CellBender; PyTorch 2.0.x predates the NumPy 2.0 ABI change and breaks at runtime if NumPy 2.x is resolved
 5. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
 6. Runs `cellbender --version` as a smoke test to verify the install
 7. Uses `--no-cache-dir` and apt list cleanup to minimize image size

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -16,6 +16,7 @@ These Docker images are built from the `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu
 - CellBender (installed from the upstream main branch): Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
 - PyTorch 2.0.1 (CUDA 11.8): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
 - NumPy 1.26.4: Pinned to the 1.x series for compatibility with PyTorch 2.0.x, which predates the NumPy 2.0 ABI change
+- pyro-ppl 1.9.1: Pinned to fix a `weakref` pickling error in pyro's optimizer serialization that causes checkpoint saves to fail with PyTorch 2.0.x
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.
@@ -113,7 +114,7 @@ The Dockerfile follows these main steps:
 1. Uses `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` as the base image, providing CUDA 11.8 libraries that support GPUs with Compute Capability >= 3.5 (including older hardware like the GTX 1080 Ti)
 2. Adds metadata labels for documentation and attribution
 3. Installs Python 3, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Pins PyTorch to a CUDA 11.8 wheel and NumPy to 1.26.4 before installing CellBender; PyTorch 2.0.x predates the NumPy 2.0 ABI change and breaks at runtime if NumPy 2.x is resolved
+4. Pins PyTorch to a CUDA 11.8 wheel, NumPy to 1.26.4, and pyro-ppl to 1.9.1 before installing CellBender; the NumPy pin avoids a runtime ABI break with PyTorch 2.0.x, and the pyro-ppl pin fixes a `weakref` pickling error that causes checkpoint saves to fail
 5. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
 6. Runs `cellbender --version` as a smoke test to verify the install
 7. Uses `--no-cache-dir` and apt list cleanup to minimize image size

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -7,19 +7,17 @@ This directory contains Docker images for CellBender, a tool for removing techni
 - `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_latest.md) )
 - `0.3.2` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_0.3.2) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_0.3.2.md) )
 
-> **Platform note:** These images are AMD64-only. PyTorch CUDA wheels are not available for ARM64, so `linux/arm64` builds are not supported.
-
 ## Image Details
 
-These Docker images are built from the NVIDIA CUDA 11.8 runtime base image (`nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04`) and include:
+These Docker images are built from Python 3.11 slim and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch 2.0.1 (CUDA 11.8): Provides consistent GPU acceleration across a wide range of NVIDIA hardware, including older GPUs such as the GTX 1080 Ti (Compute Capability 6.1); falls back to CPU automatically when no GPU is detected
+- PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
-The images are designed to be minimal and focused on CellBender with its essential dependencies. Using the NVIDIA base image with a CUDA 11.8 wheel ensures the CUDA runtime is bundled inside the image and compatible with GPUs back to Compute Capability 3.5, so GPU behavior is consistent regardless of what CUDA version is installed on the host.
+The images are designed to be minimal and focused on CellBender with its essential dependencies.
 
-> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, the `latest` image installs CellBender from the upstream main branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The main branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
+> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, CellBender is currently installed from the upstream main branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The master branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
 
 ## Citation
 
@@ -99,7 +97,7 @@ apptainer run --bind /path/to/data:/data cellbender_latest.sif \
 
 ### GPU support
 
-These images bundle PyTorch 2.0.1 with CUDA 11.8, so GPU behavior is consistent regardless of what CUDA version is installed on the host. CUDA 11.8 supports NVIDIA GPUs back to Compute Capability 3.5, including older cards such as the GTX 1080 Ti (CC 6.1). On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
+The PyTorch included in this image is built with CUDA support. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
 
 ### Output files
 
@@ -109,13 +107,12 @@ CellBender produces an `.h5` output file containing corrected counts and latent 
 
 The Dockerfile follows these main steps:
 
-1. Uses `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` as the base image to bundle a CUDA runtime compatible with GPUs back to Compute Capability 3.5
+1. Uses Python 3.11 slim as the base image
 2. Adds metadata labels for documentation and attribution
-3. Installs Python 3.11, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Installs PyTorch 2.0.1 with CUDA 11.8 wheels via `python3.11 -m pip` to prevent pip from pulling in a CUDA 12.x build as a transitive dependency
-5. Installs CellBender directly from the main branch on GitHub (for `latest`), incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release
-6. Runs `cellbender --version` as a smoke test to verify the install
-7. Uses `--no-cache-dir` and apt list cleanup to minimize image size
+3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
+4. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
+5. Runs `cellbender --version` as a smoke test to verify the install
+6. Uses `--no-cache-dir` and apt list cleanup to minimize image size
 
 ## Security Scanning and CVEs
 

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -7,17 +7,19 @@ This directory contains Docker images for CellBender, a tool for removing techni
 - `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_latest.md) )
 - `0.3.2` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_0.3.2) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_0.3.2.md) )
 
+> **Platform note:** These images are AMD64-only. PyTorch CUDA wheels are not available for ARM64, so `linux/arm64` builds are not supported.
+
 ## Image Details
 
-These Docker images are built from Python 3.11 slim and include:
+These Docker images are built from the NVIDIA CUDA 12.6 runtime base image (`nvidia/cuda:12.6.3-runtime-ubuntu24.04`) and include:
 
 - CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- PyTorch 2.6.0 (CUDA 12.6): Provides consistent GPU acceleration across different host environments when run with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is detected
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
-The images are designed to be minimal and focused on CellBender with its essential dependencies.
+The images are designed to be minimal and focused on CellBender with its essential dependencies. Using the NVIDIA base image ensures the CUDA runtime is bundled inside the image, so GPU behavior is consistent regardless of what CUDA version is installed on the host.
 
-> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, CellBender is currently installed from the upstream main branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The master branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
+> **Note:** As an exception to this repository's standard practice of pinning to a specific release version, the `latest` image installs CellBender from the upstream main branch. This is necessary because the v0.3.2 PyPI release contains a checkpoint serialization bug that prevents normal use. The main branch includes the upstream fix (broadinstitute/CellBender#444). This image will be updated to pin a specific version once v0.3.3 is released.
 
 ## Citation
 
@@ -97,7 +99,7 @@ apptainer run --bind /path/to/data:/data cellbender_latest.sif \
 
 ### GPU support
 
-The PyTorch included in this image is built with CUDA support. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
+These images bundle PyTorch 2.6.0 with CUDA 12.6, so GPU behavior is consistent regardless of what CUDA version is installed on the host. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
 
 ### Output files
 
@@ -107,12 +109,13 @@ CellBender produces an `.h5` output file containing corrected counts and latent 
 
 The Dockerfile follows these main steps:
 
-1. Uses Python 3.11 slim as the base image
+1. Uses `nvidia/cuda:12.6.3-runtime-ubuntu24.04` as the base image to bundle the CUDA runtime
 2. Adds metadata labels for documentation and attribution
-3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
-5. Runs `cellbender --version` as a smoke test to verify the install
-6. Uses `--no-cache-dir` and apt list cleanup to minimize image size
+3. Installs Python 3, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
+4. Installs PyTorch 2.6.0 with CUDA 12.6 wheels to ensure consistent GPU behavior across hosts
+5. Installs CellBender directly from the main branch on GitHub (for `latest`), incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release
+6. Runs `cellbender --version` as a smoke test to verify the install
+7. Uses `--no-cache-dir` and apt list cleanup to minimize image size
 
 ## Security Scanning and CVEs
 

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -7,11 +7,13 @@ This directory contains Docker images for CellBender, a tool for removing techni
 - `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_latest.md) )
 - `0.3.2` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/Dockerfile_0.3.2) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/cellbender/CVEs_0.3.2.md) )
 
+> **Note:** Both tags currently install from the upstream `main` branch rather than a pinned release. See [Image Details](#image-details) for the reason.
+
 ## Image Details
 
-These Docker images are built from Python 3.11 slim and include:
+These Docker images are built from the `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` base image and include:
 
-- CellBender v0.3.2: Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
+- CellBender (installed from the upstream main branch): Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
 - PyTorch (CUDA-enabled): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
@@ -97,7 +99,7 @@ apptainer run --bind /path/to/data:/data cellbender_latest.sif \
 
 ### GPU support
 
-The PyTorch included in this image is built with CUDA support. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
+The PyTorch included in this image is built with CUDA 11.8 support, targeting GPUs with Compute Capability >= 3.5 (including older hardware like GTX 1080 Ti). The CUDA version is pinned in the image itself rather than inherited from the host, so behavior is consistent regardless of the driver version on the host machine. On machines with an NVIDIA GPU and compatible drivers, pass `--gpus all` to Docker (or `--nv` to Apptainer) and add the `--cuda` flag to the `cellbender` command. CellBender will automatically fall back to CPU if no GPU is detected.
 
 ### Output files
 
@@ -107,12 +109,13 @@ CellBender produces an `.h5` output file containing corrected counts and latent 
 
 The Dockerfile follows these main steps:
 
-1. Uses Python 3.11 slim as the base image
+1. Uses `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` as the base image, providing CUDA 11.8 libraries that support GPUs with Compute Capability >= 3.5 (including older hardware like the GTX 1080 Ti)
 2. Adds metadata labels for documentation and attribution
-3. Installs HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
-5. Runs `cellbender --version` as a smoke test to verify the install
-6. Uses `--no-cache-dir` and apt list cleanup to minimize image size
+3. Installs Python 3, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
+4. Pins PyTorch to a CUDA 11.8 wheel before installing CellBender to prevent pip from pulling in a CUDA 12.x build as a transitive dependency
+5. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
+6. Runs `cellbender --version` as a smoke test to verify the install
+7. Uses `--no-cache-dir` and apt list cleanup to minimize image size
 
 ## Security Scanning and CVEs
 

--- a/cellbender/README.md
+++ b/cellbender/README.md
@@ -14,9 +14,9 @@ This directory contains Docker images for CellBender, a tool for removing techni
 These Docker images are built from the `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` base image and include:
 
 - CellBender (installed from the upstream main branch): Removes ambient RNA and barcode swapping artifacts from scRNA-seq/snRNA-seq count matrices using a deep generative model
-- PyTorch 2.0.1 (CUDA 11.8): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
-- NumPy 1.26.4: Pinned to the 1.x series for compatibility with PyTorch 2.0.x, which predates the NumPy 2.0 ABI change
-- pyro-ppl 1.9.1: Pinned to fix a `weakref` pickling error in pyro's optimizer serialization that causes checkpoint saves to fail with PyTorch 2.0.x
+- PyTorch 2.2.2 (CUDA 11.8): Provides GPU acceleration when run on a machine with compatible NVIDIA drivers and the `--cuda` flag; falls back to CPU automatically when no GPU is available
+- NumPy 1.26.4: Pinned to the 1.x series for compatibility with PyTorch 2.2.x, which does not declare a NumPy upper bound but breaks at runtime with NumPy 2.x
+- pyro-ppl 1.9.1: Pinned for PyTorch 2.x compatibility
 - PyTables/HDF5: Required for reading and writing `.h5` count matrix files
 
 The images are designed to be minimal and focused on CellBender with its essential dependencies.
@@ -114,7 +114,7 @@ The Dockerfile follows these main steps:
 1. Uses `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` as the base image, providing CUDA 11.8 libraries that support GPUs with Compute Capability >= 3.5 (including older hardware like the GTX 1080 Ti)
 2. Adds metadata labels for documentation and attribution
 3. Installs Python 3, pip, and HDF5 system libraries (`libhdf5-dev`) required by the PyTables dependency
-4. Pins PyTorch to a CUDA 11.8 wheel, NumPy to 1.26.4, and pyro-ppl to 1.9.1 before installing CellBender; the NumPy pin avoids a runtime ABI break with PyTorch 2.0.x, and the pyro-ppl pin fixes a `weakref` pickling error that causes checkpoint saves to fail
+4. Pins PyTorch to `2.2.2+cu118`, NumPy to 1.26.4, and pyro-ppl to 1.9.1 before installing CellBender; PyTorch 2.2 is the minimum version where LR scheduler state dicts are safely picklable (fixing checkpoint save failures), and the NumPy pin avoids a runtime ABI break
 5. Installs CellBender directly from the master branch on GitHub, incorporating upstream fixes for checkpoint serialization that are not yet in the v0.3.2 PyPI release; will be updated to pin a specific version once v0.3.3 is released
 6. Runs `cellbender --version` as a smoke test to verify the install
 7. Uses `--no-cache-dir` and apt list cleanup to minimize image size


### PR DESCRIPTION
## Type of Change

- Bug fix
- Documentation update

## Description

Switches the CellBender base image from `python:3.11-slim` to `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` to pin the CUDA version inside the image rather than inheriting it from the host. The previous approach caused GPU compatibility issues in practice when the host CUDA driver version didn't match what CellBender/PyTorch expected.

Key changes:
- **Base image:** `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04` (CUDA 11.8, supports Compute Capability >= 3.5, including older GPUs like GTX 1080 Ti)
- **PyTorch:** Pinned to `torch==2.0.1+cu118` from the PyTorch CUDA 11.8 wheel index, installed before CellBender to prevent pip from pulling in a CUDA 12.x build as a transitive dependency
- **NumPy:** Pinned to `numpy==1.26.4` (1.x series); PyTorch 2.0.x predates the NumPy 2.0 ABI change and breaks at runtime if NumPy 2.x is resolved
- **pyro-ppl:** Pinned to `pyro-ppl==1.9.1` to fix a `weakref` pickling error in pyro's optimizer serialization that causes checkpoint saves to fail with PyTorch 2.0.x
- **pip upgrade:** Ubuntu 22.04 ships pip 22.0.2, which fails to register entry points when a package name resolves to `UNKNOWN` (a known issue with CellBender's `setuptools-git-versioning` setup and pip's shallow git clone). pip is upgraded to 26.1.2 before installing CellBender to work around this.
- Both `Dockerfile_latest` and `Dockerfile_0.3.2` now install CellBender from the upstream `main` branch (rather than the PyPI 0.3.2 release), since the PyPI release contains a checkpoint serialization bug fixed in the repo but not yet in a versioned release.
- Added `cellbender` to `amd64_only_tools.txt` since PyTorch CUDA wheels are not available for ARM64.
- Updated `AGENTS.md` and `CONTRIBUTING.md` to document the NVIDIA CUDA base image convention and the `amd64_only_tools.txt` requirement for PyTorch CUDA images.

## Testing

- Built successfully with `make build_amd64 IMAGE=cellbender`
- Confirmed `cellbender --version` smoke test passes in the built image

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make build_amd64 IMAGE=cellbender`
- [x] Image builds successfully for target platform(s)

## Additional Context

The image is AMD64-only due to PyTorch CUDA wheels not being available for ARM64.