### PR TITLE
Adding initial draft of CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "WILDS Docker Library"
+abstract: "A curated collection of Docker images for bioinformatics tools, providing reproducible, well-tested containers for use in WILDS genomics workflows and beyond."
+version: 0.1.0
+date-released: "2026-02-08"
+license: MIT
+repository-code: "https://github.com/getwilds/wilds-docker-library"
+url: "https://getwilds.org/"
+contact:
+  - email: wilds@fredhutch.org
+    name: "Fred Hutch OCDO WILDS"
+keywords:
+  - bioinformatics
+  - docker
+  - genomics
+  - containers
+  - workflows
+authors:
+  - family-names: Firman
+    given-names: Taylor
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0009-0002-2052-1084"
+  - family-names: Bishop
+    given-names: Emma
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0000-0003-4484-3336"
+  - family-names: Salerno
+    given-names: Stephen
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0000-0003-2763-0494"
+  - family-names: Agarwal
+    given-names: Sanaz
+    affiliation: "Fred Hutch Cancer Center"
+    orcid: "https://orcid.org/0000-0002-1808-7568"

--- a/README.md
+++ b/README.md
@@ -232,6 +232,26 @@ For questions, bug reports, or feature requests:
 - Open an [issue](https://github.com/getwilds/wilds-docker-library/issues)
 - Email the Fred Hutch Office of the Chief Data Officer at wilds@fredhutch.org
 
+## Citation
+
+If you use the WILDS Docker Library in your research, please cite it. A Zenodo DOI is forthcoming; this section will be updated once the repository is registered.
+
+> Firman, T., Bishop, E., et al. (2026). WILDS Docker Library [Computer software]. GitHub. https://github.com/getwilds/wilds-docker-library
+
+BibTeX:
+
+```bibtex
+@software{wilds_docker_library,
+  author    = {Firman, Taylor and Bishop, Emma and others},
+  title     = {WILDS Docker Library},
+  year      = {2026},
+  publisher = {GitHub},
+  url       = {https://github.com/getwilds/wilds-docker-library}
+}
+```
+
+A machine-readable citation is also available in [CITATION.cff](CITATION.cff), which GitHub uses to power the "Cite this repository" button in the sidebar.
+
 ## License
 
 Distributed under the MIT License. See `LICENSE` for details.


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: adds machine-readable citation metadata (`CITATION.cff`)

## Description

Adds a `CITATION.cff` file to the repository root so that GitHub surfaces a "Cite this repository" button in the sidebar and tools like Zotero can extract structured citation metadata automatically. Also adds a `## Citation` section to the top-level README following the same style as the WILDS WDL Library, with an inline citation, BibTeX block, and a pointer to `CITATION.cff`.

DOI fields are omitted for now pending Zenodo registration. Once the repo is connected to Zenodo and a release triggers DOI minting, the `identifiers:` block in `CITATION.cff` and the README citation should be updated to include version-specific and concept DOIs (see WILDS WDL Library as a reference).