### PR TITLE
Adding initial version of `edger` WILDS Docker image

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -4,6 +4,7 @@ cellbender
 cellranger
 colabfold
 deseq2
+edger
 diamond
 esmfold
 glimpse2

--- a/edger/CVEs_4.10.0.md
+++ b/edger/CVEs_4.10.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/edger:4.10.0
 
-Report generated on 2026-07-23 02:55:34 PST
+Report generated on 2026-07-23 04:53:40 PST
 
 ## Platform Coverage
 
@@ -32,7 +32,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 ```text
 Target     │  getwilds/edger:4.10.0   │   16C   215H   1891M   311L     2?  
-   digest   │  e3c0b213a1da                    │                                     
+   digest   │  731bff12e3fe                    │                                     
  Base image │  bioconductor/bioconductor:3.23  │   16C   215H   1891M   309L     2?  
 
 Policy status  FAILED  (3/7 policies met)

--- a/edger/CVEs_4.10.0.md
+++ b/edger/CVEs_4.10.0.md
@@ -1,0 +1,55 @@
+# Vulnerability Report for getwilds/edger:4.10.0
+
+Report generated on 2026-07-23 02:55:34 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 215 |
+| 🟡 Medium | 1891 |
+| 🟢 Low | 311 |
+| ⚪ Unknown | 2 |
+
+## 🐳 Base Image
+
+**Image:** `bioconductor/bioconductor:3.23`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 215 |
+| 🟡 Medium | 1891 |
+| 🟢 Low | 309 |
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target     │  getwilds/edger:4.10.0   │   16C   215H   1891M   311L     2?  
+   digest   │  e3c0b213a1da                    │                                     
+ Base image │  bioconductor/bioconductor:3.23  │   16C   215H   1891M   309L     2?  
+
+Policy status  FAILED  (3/7 policies met)
+
+ Status │                     Policy                     │           Results           
+────────┼────────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                    │                             
+ !      │ Copyleft licensed packages found               │    3075 packages            
+ !      │ Fixable critical or high vulnerabilities found │   16C   174H     0M     0L  
+ ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                        │                             
+ ✓      │ No unapproved base images                      │    0 deviations             
+ !      │ Required supply chain attestations missing     │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/edger:4.10.0
+    View vulnerabilities → docker scout cves getwilds/edger:4.10.0
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/edger:4.10.0
+```
+</details>

--- a/edger/CVEs_latest.md
+++ b/edger/CVEs_latest.md
@@ -1,0 +1,55 @@
+# Vulnerability Report for getwilds/edger:latest
+
+Report generated on 2026-07-23 03:05:07 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 215 |
+| 🟡 Medium | 1891 |
+| 🟢 Low | 311 |
+| ⚪ Unknown | 2 |
+
+## 🐳 Base Image
+
+**Image:** `bioconductor/bioconductor:3.23`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 215 |
+| 🟡 Medium | 1891 |
+| 🟢 Low | 309 |
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target     │  getwilds/edger:latest   │   16C   215H   1891M   311L     2?  
+   digest   │  b89464d771fe                    │                                     
+ Base image │  bioconductor/bioconductor:3.23  │   16C   215H   1891M   309L     2?  
+
+Policy status  FAILED  (3/7 policies met)
+
+ Status │                     Policy                     │           Results           
+────────┼────────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                    │                             
+ !      │ Copyleft licensed packages found               │    3075 packages            
+ !      │ Fixable critical or high vulnerabilities found │   16C   174H     0M     0L  
+ ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                        │                             
+ ✓      │ No unapproved base images                      │    0 deviations             
+ !      │ Required supply chain attestations missing     │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/edger:latest
+    View vulnerabilities → docker scout cves getwilds/edger:latest
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/edger:latest
+```
+</details>

--- a/edger/CVEs_latest.md
+++ b/edger/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/edger:latest
 
-Report generated on 2026-07-23 03:05:07 PST
+Report generated on 2026-07-23 05:03:27 PST
 
 ## Platform Coverage
 
@@ -32,7 +32,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 ```text
 Target     │  getwilds/edger:latest   │   16C   215H   1891M   311L     2?  
-   digest   │  b89464d771fe                    │                                     
+   digest   │  0571ec6244db                    │                                     
  Base image │  bioconductor/bioconductor:3.23  │   16C   215H   1891M   309L     2?  
 
 Policy status  FAILED  (3/7 policies met)

--- a/edger/Dockerfile_4.10.0
+++ b/edger/Dockerfile_4.10.0
@@ -1,0 +1,26 @@
+# Use Bioconductor base image
+FROM bioconductor/bioconductor_docker:RELEASE_3_23
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="edger"
+LABEL org.opencontainers.image.description="Docker image for edgeR differential expression analysis of digital gene expression data in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="4.10.0"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install edgeR and commonly used companion packages, then smoke test
+RUN R -e "BiocManager::install(c('edgeR', 'limma', 'ggplot2', 'pheatmap', 'RColorBrewer', 'optparse'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
+  && R -e "library(edgeR); packageVersion('edgeR')"
+
+# Set working directory
+WORKDIR /data

--- a/edger/Dockerfile_4.10.0
+++ b/edger/Dockerfile_4.10.0
@@ -3,7 +3,7 @@ FROM bioconductor/bioconductor_docker:RELEASE_3_23
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="edger"
-LABEL org.opencontainers.image.description="Docker image for edgeR differential expression analysis of digital gene expression data in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.description="Docker image for edgeR differential expression analysis of RNA-seq data in Fred Hutch OCDO's WILDS"
 LABEL org.opencontainers.image.version="4.10.0"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/

--- a/edger/Dockerfile_latest
+++ b/edger/Dockerfile_latest
@@ -3,7 +3,7 @@ FROM bioconductor/bioconductor_docker:RELEASE_3_23
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="edger"
-LABEL org.opencontainers.image.description="Docker image for edgeR differential expression analysis of digital gene expression data in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.description="Docker image for edgeR differential expression analysis of RNA-seq data in Fred Hutch OCDO's WILDS"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/

--- a/edger/Dockerfile_latest
+++ b/edger/Dockerfile_latest
@@ -1,0 +1,26 @@
+# Use Bioconductor base image
+FROM bioconductor/bioconductor_docker:RELEASE_3_23
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="edger"
+LABEL org.opencontainers.image.description="Docker image for edgeR differential expression analysis of digital gene expression data in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install edgeR and commonly used companion packages, then smoke test
+RUN R -e "BiocManager::install(c('edgeR', 'limma', 'ggplot2', 'pheatmap', 'RColorBrewer', 'optparse'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
+  && R -e "library(edgeR); packageVersion('edgeR')"
+
+# Set working directory
+WORKDIR /data

--- a/edger/README.md
+++ b/edger/README.md
@@ -1,0 +1,127 @@
+# edgeR
+
+This directory contains Docker images for edgeR, a Bioconductor package for differential expression analysis of digital gene expression data such as RNA-seq, ChIP-seq, ATAC-seq, and similar count-based omics datasets.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/edger/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/edger/CVEs_latest.md) )
+- `4.10.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/edger/Dockerfile_4.10.0) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/edger/CVEs_4.10.0.md) )
+
+## Image Details
+
+These Docker images are built from the Bioconductor base image (RELEASE_3_23) and include:
+
+- edgeR v4.10.0: Differential expression analysis using negative binomial models with empirical Bayes estimation, exact tests, GLMs, and quasi-likelihood methods
+- limma: Linear models for microarray and RNA-seq data, frequently used alongside edgeR for voom-based analyses
+- ggplot2: Grammar of graphics plotting for visualization of results
+- pheatmap and RColorBrewer: Heatmap visualization of expression patterns
+- optparse: Command-line argument parsing for scripted workflows
+
+The images are designed to provide a focused environment for differential expression analysis with edgeR and its most common companion tools.
+
+## Platform Availability
+
+**Note:** This image is only built for **linux/amd64** architecture. edgeR and its C++ dependencies have compilation issues on ARM64 platforms.
+
+## Citation
+
+If you use edgeR in your research, please cite the original authors:
+
+```
+Robinson MD, McCarthy DJ, Smyth GK (2010). edgeR: a Bioconductor package for
+differential expression analysis of digital gene expression data.
+Bioinformatics, 26(1), 139-140. https://doi.org/10.1093/bioinformatics/btp616
+
+McCarthy DJ, Chen Y, Smyth GK (2012). Differential expression analysis of
+multifactor RNA-Seq experiments with respect to biological variation.
+Nucleic Acids Research, 40(10), 4288-4297. https://doi.org/10.1093/nar/gks042
+
+Chen Y, Lun ATL, Smyth GK (2016). From reads to genes to pathways: differential
+expression analysis of RNA-Seq experiments using Rsubread and the edgeR
+quasi-likelihood pipeline. F1000Research, 5, 1438.
+https://doi.org/10.12688/f1000research.8987.2
+```
+
+**Tool homepage:** https://bioconductor.org/packages/release/bioc/html/edgeR.html
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/edger:latest
+
+# Or pull a specific version
+docker pull getwilds/edger:4.10.0
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/edger:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/edger:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/edger:4.10.0
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/edger:latest
+```
+
+### Example Commands
+
+```bash
+# Launch an interactive R session with edgeR loaded
+docker run --rm -it -v /path/to/data:/data getwilds/edger:latest R
+
+# Run an R script that performs edgeR differential expression analysis
+docker run --rm -v /path/to/data:/data getwilds/edger:latest \
+  Rscript /data/edger_analysis.R
+
+# Run a quick inline edgeR analysis on count data
+docker run --rm -v /path/to/data:/data getwilds/edger:latest R -e "
+  library(edgeR)
+  counts <- read.table('/data/counts.txt', header=TRUE, row.names=1)
+  group <- factor(c('control','control','treatment','treatment'))
+  dge <- DGEList(counts=counts, group=group)
+  dge <- calcNormFactors(dge)
+  dge <- estimateDisp(dge)
+  et <- exactTest(dge)
+  write.csv(topTags(et, n=Inf), '/data/edger_results.csv')
+"
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/edger:latest \
+  Rscript /data/edger_analysis.R
+
+# Or a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data edger_latest.sif \
+  Rscript /data/edger_analysis.R
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Bioconductor RELEASE_3_23 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Sets R library paths to prevent host library contamination in Apptainer
+4. Installs edgeR, limma, and visualization packages via BiocManager
+5. Runs a smoke test to confirm edgeR loads and reports its version
+6. Sets `/data` as the default working directory
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/edger), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new Docker image for [edgeR](https://bioconductor.org/packages/release/bioc/html/edgeR.html) (v4.10.0), a Bioconductor package for differential expression analysis of digital gene expression data (RNA-seq, ChIP-seq, ATAC-seq, and other count-based omics datasets). edgeR uses negative binomial models with empirical Bayes estimation, exact tests, GLMs, and quasi-likelihood methods.

**Base image:** `bioconductor/bioconductor_docker:RELEASE_3_23` (current stable Bioconductor release)

**Installation method:** `BiocManager::install()` within the Bioconductor base image

**Packages included:** edgeR, limma (for voom-based workflows), ggplot2, pheatmap, RColorBrewer, optparse

edgeR is added to `amd64_only_tools.txt` because its C++ dependencies have known compilation issues on ARM64, consistent with how `deseq2` and `seurat` are handled in this repo.

## Testing

**How did you test these changes?**

- Ran `make lint IMAGE=edger` (hadolint v2.12.0), passed with no warnings or errors
- Ran `make build_amd64 IMAGE=edger`, passed with no errors

**Did the tests pass?**

Yes.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)

## Additional Context

- Used RELEASE_3_23 (current Bioconductor release) rather than the older RELEASE_3_17 used in the existing `deseq2` image.
- The smoke test (`library(edgeR); packageVersion('edgeR')`) is merged into the same `RUN` layer as the install step to avoid the DL3059 hadolint notice about consecutive `RUN` instructions.
- limma is included as a direct companion since edgeR workflows commonly use `voom()` from limma for precision-weight-based analyses.