### PR TITLE
Adding initial draft of `gwaslab` WILDS Docker image

### DIFF
--- a/.agents/skills/new-image/SKILL.md
+++ b/.agents/skills/new-image/SKILL.md
@@ -27,7 +27,7 @@ Before writing any files, research the tool to understand:
 - Create a new directory named after the tool (lowercase, hyphens for multi-word names)
 - Read `template/Dockerfile_template` first as the formatting reference
 - Create `Dockerfile_latest` following ALL Dockerfile requirements from `AGENTS.md`:
-  - OCI metadata labels (title, description, version, authors, source URL, MIT license)
+  - OCI metadata labels (title, description, version, authors, source URL, MIT license). Keep `description` to 100 bytes or less, since the overview upload rejects longer values (check with `printf '%s' "$desc" | wc -c`)
   - `SHELL ["/bin/bash", "-o", "pipefail", "-c"]`
   - Pinned versions for system packages using `apt-cache policy`
   - A smoke test `RUN` command verifying the install (e.g., `tool --version`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Makefile                # local dev commands
 
 Every Dockerfile **must** include:
 
-1. **OCI metadata labels** — title, description, version, authors (`wilds@fredhutch.org`), source URL, MIT license
+1. **OCI metadata labels** — title, description, version, authors (`wilds@fredhutch.org`), source URL, MIT license. The `description` label must be 100 bytes or less (the overview upload rejects longer values)
 2. **Shell config** — `SHELL ["/bin/bash", "-o", "pipefail", "-c"]`
 3. **Pinned versions** — use `apt-cache policy` for system packages; never use `latest` in downloads
 4. **Smoke test** — a `RUN` command verifying the install (e.g., `tool --version`)

--- a/gwaslab/CVEs_4.2.1.md
+++ b/gwaslab/CVEs_4.2.1.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/gwaslab:4.2.1
 
-Report generated on 2026-07-30 17:26:55 PST
+Report generated on 2026-07-30 19:00:07 PST
 
 ## Platform Coverage
 
@@ -36,7 +36,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 ```text
 Target             │  getwilds/gwaslab:4.2.1-amd64  │    1C     2H     7M    29L     7?  
-   digest           │  16ce47cc20c3                          │                                    
+   digest           │  95db968f9e9d                          │                                    
  Base image         │  python:3.12-slim                      │    1C     2H     7M    29L     7?  
  Updated base image │  python:3.13-slim                      │    1C     2H     3M    28L     7?  
                     │                                        │                  -4     -1         

--- a/gwaslab/CVEs_4.2.1.md
+++ b/gwaslab/CVEs_4.2.1.md
@@ -1,0 +1,63 @@
+# Vulnerability Report for getwilds/gwaslab:4.2.1
+
+Report generated on 2026-07-30 17:26:55 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 1 |
+| 🟠 High | 2 |
+| 🟡 Medium | 7 |
+| 🟢 Low | 29 |
+| ⚪ Unknown | 7 |
+
+## 🐳 Base Image
+
+**Image:** `python:3.12-slim`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 1 |
+| 🟠 High | 2 |
+| 🟡 Medium | 7 |
+| 🟢 Low | 29 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.13-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/gwaslab:4.2.1-amd64  │    1C     2H     7M    29L     7?  
+   digest           │  16ce47cc20c3                          │                                    
+ Base image         │  python:3.12-slim                      │    1C     2H     7M    29L     7?  
+ Updated base image │  python:3.13-slim                      │    1C     2H     3M    28L     7?  
+                    │                                        │                  -4     -1         
+
+Policy status  FAILED  (4/7 policies met)
+Health score  B  (72%)
+
+ Status │                   Policy                    │           Results           
+────────┼─────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                 │                             
+ !      │ Copyleft licensed packages found            │    368 packages             
+ ✓      │ No fixable critical or high vulnerabilities │    0C     0H     0M     0L  
+ ✓      │ No high-profile vulnerabilities             │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                     │                             
+ ✓      │ No unapproved base images                   │    0 deviations             
+ !      │ Required supply chain attestations missing  │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/gwaslab:4.2.1-amd64
+    View vulnerabilities → docker scout cves getwilds/gwaslab:4.2.1-amd64
+    View base image update recommendations → docker scout recommendations getwilds/gwaslab:4.2.1-amd64
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/gwaslab:4.2.1-amd64
+```
+</details>

--- a/gwaslab/CVEs_latest.md
+++ b/gwaslab/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/gwaslab:latest
 
-Report generated on 2026-07-30 18:02:10 PST
+Report generated on 2026-07-30 19:31:47 PST
 
 ## Platform Coverage
 
@@ -36,7 +36,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 
 ```text
 Target             │  getwilds/gwaslab:latest-amd64  │    1C     2H     7M    29L     7?  
-   digest           │  766000715c0d                           │                                    
+   digest           │  594f0a578554                           │                                    
  Base image         │  python:3.12-slim                       │    1C     2H     7M    29L     7?  
  Updated base image │  python:3.13-slim                       │    1C     2H     3M    28L     7?  
                     │                                         │                  -4     -1         

--- a/gwaslab/CVEs_latest.md
+++ b/gwaslab/CVEs_latest.md
@@ -1,0 +1,63 @@
+# Vulnerability Report for getwilds/gwaslab:latest
+
+Report generated on 2026-07-30 18:02:10 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 1 |
+| 🟠 High | 2 |
+| 🟡 Medium | 7 |
+| 🟢 Low | 29 |
+| ⚪ Unknown | 7 |
+
+## 🐳 Base Image
+
+**Image:** `python:3.12-slim`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 1 |
+| 🟠 High | 2 |
+| 🟡 Medium | 7 |
+| 🟢 Low | 29 |
+
+## 🔄 Recommendations
+
+**Updated base image:** `python:3.13-slim`
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target             │  getwilds/gwaslab:latest-amd64  │    1C     2H     7M    29L     7?  
+   digest           │  766000715c0d                           │                                    
+ Base image         │  python:3.12-slim                       │    1C     2H     7M    29L     7?  
+ Updated base image │  python:3.13-slim                       │    1C     2H     3M    28L     7?  
+                    │                                         │                  -4     -1         
+
+Policy status  FAILED  (4/7 policies met)
+Health score  B  (72%)
+
+ Status │                   Policy                    │           Results           
+────────┼─────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                 │                             
+ !      │ Copyleft licensed packages found            │    368 packages             
+ ✓      │ No fixable critical or high vulnerabilities │    0C     0H     0M     0L  
+ ✓      │ No high-profile vulnerabilities             │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                     │                             
+ ✓      │ No unapproved base images                   │    0 deviations             
+ !      │ Required supply chain attestations missing  │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/gwaslab:latest-amd64
+    View vulnerabilities → docker scout cves getwilds/gwaslab:latest-amd64
+    View base image update recommendations → docker scout recommendations getwilds/gwaslab:latest-amd64
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/gwaslab:latest-amd64
+```
+</details>

--- a/gwaslab/Dockerfile_4.2.1
+++ b/gwaslab/Dockerfile_4.2.1
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="gwaslab"
-LABEL org.opencontainers.image.description="Docker image for GWASLab, a Python toolkit for processing and visualizing GWAS summary statistics, in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.description="Docker image for GWASLab, a Python toolkit for GWAS summary statistics"
 LABEL org.opencontainers.image.version="4.2.1"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/

--- a/gwaslab/Dockerfile_4.2.1
+++ b/gwaslab/Dockerfile_4.2.1
@@ -1,0 +1,19 @@
+# Using Python base image
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gwaslab"
+LABEL org.opencontainers.image.description="Docker image for GWASLab, a Python toolkit for processing and visualizing GWAS summary statistics, in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="4.2.1"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Ensure pipelines fail if any command fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing GWASLab via pip and verifying the installation
+RUN pip install --no-cache-dir gwaslab==4.2.1 \
+  && python -c "import gwaslab as gl; print(gl.__version__)"

--- a/gwaslab/Dockerfile_4.2.1
+++ b/gwaslab/Dockerfile_4.2.1
@@ -14,6 +14,13 @@ LABEL org.opencontainers.image.licenses=MIT
 # Ensure pipelines fail if any command fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Installing GWASLab via pip and verifying the installation
-RUN pip install --no-cache-dir gwaslab==4.2.1 \
-  && python -c "import gwaslab as gl; print(gl.__version__)"
+# Installing build tools (needed to compile scikit-allel from source on
+# architectures without prebuilt wheels, e.g. arm64), installing GWASLab via
+# pip, then removing the build tools to keep the image slim
+RUN apt-get update \
+  && BUILD_ESSENTIAL_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends build-essential="${BUILD_ESSENTIAL_VERSION}" \
+  && pip install --no-cache-dir gwaslab==4.2.1 \
+  && python -c "import gwaslab as gl; print(gl.__version__)" \
+  && apt-get purge -y --auto-remove build-essential \
+  && rm -rf /var/lib/apt/lists/*

--- a/gwaslab/Dockerfile_latest
+++ b/gwaslab/Dockerfile_latest
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="gwaslab"
-LABEL org.opencontainers.image.description="Docker image for GWASLab, a Python toolkit for processing and visualizing GWAS summary statistics, in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.description="Docker image for GWASLab, a Python toolkit for GWAS summary statistics"
 LABEL org.opencontainers.image.version="latest"
 LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
 LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/

--- a/gwaslab/Dockerfile_latest
+++ b/gwaslab/Dockerfile_latest
@@ -14,6 +14,13 @@ LABEL org.opencontainers.image.licenses=MIT
 # Ensure pipelines fail if any command fails
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Installing GWASLab via pip and verifying the installation
-RUN pip install --no-cache-dir gwaslab==4.2.1 \
-  && python -c "import gwaslab as gl; print(gl.__version__)"
+# Installing build tools (needed to compile scikit-allel from source on
+# architectures without prebuilt wheels, e.g. arm64), installing GWASLab via
+# pip, then removing the build tools to keep the image slim
+RUN apt-get update \
+  && BUILD_ESSENTIAL_VERSION=$(apt-cache policy build-essential | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends build-essential="${BUILD_ESSENTIAL_VERSION}" \
+  && pip install --no-cache-dir gwaslab==4.2.1 \
+  && python -c "import gwaslab as gl; print(gl.__version__)" \
+  && apt-get purge -y --auto-remove build-essential \
+  && rm -rf /var/lib/apt/lists/*

--- a/gwaslab/Dockerfile_latest
+++ b/gwaslab/Dockerfile_latest
@@ -1,0 +1,19 @@
+# Using Python base image
+FROM python:3.12-slim
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="gwaslab"
+LABEL org.opencontainers.image.description="Docker image for GWASLab, a Python toolkit for processing and visualizing GWAS summary statistics, in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Ensure pipelines fail if any command fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Installing GWASLab via pip and verifying the installation
+RUN pip install --no-cache-dir gwaslab==4.2.1 \
+  && python -c "import gwaslab as gl; print(gl.__version__)"

--- a/gwaslab/README.md
+++ b/gwaslab/README.md
@@ -1,0 +1,113 @@
+# GWASLab
+
+This directory contains Docker images for GWASLab, a Python-based toolkit for loading, processing, quality controlling, visualizing, and analyzing genome-wide association study (GWAS) summary statistics.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/gwaslab/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/gwaslab/CVEs_latest.md) )
+- `4.2.1` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/gwaslab/Dockerfile_4.2.1) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/gwaslab/CVEs_4.2.1.md) )
+
+## Image Details
+
+These Docker images are built from the Python 3.12 slim image and include:
+
+- GWASLab v4.2.1: A toolkit for standardizing, harmonizing, quality controlling, and visualizing GWAS summary statistics
+- Its full dependency stack (pandas, numpy, scipy, matplotlib, seaborn, pysam, polars, and others), installed automatically via pip
+
+The images are designed to be minimal and focused on GWASLab with its essential dependencies.
+
+## Citation
+
+If you use GWASLab in your research, please cite the original authors:
+
+```
+He, Y., Koiko, M., Shimmori, Y., Kamatani, Y. (2023). GWASLab: a Python package
+for processing and visualizing GWAS summary statistics. Preprint at Jxiv, 2023-5.
+https://doi.org/10.51094/jxiv.370
+```
+
+**Tool homepage:** https://cloufield.github.io/gwaslab/
+
+**Source repository:** https://github.com/Cloufield/gwaslab
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/gwaslab:latest
+
+# Or pull a specific version
+docker pull getwilds/gwaslab:4.2.1
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/gwaslab:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/gwaslab:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/gwaslab:4.2.1
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/gwaslab:latest
+```
+
+### Example Commands
+
+```bash
+# Example 1: Check the installed GWASLab version
+docker run --rm getwilds/gwaslab:latest \
+  python -c "import gwaslab as gl; print(gl.__version__)"
+
+# Example 2: Load and standardize a sumstats file, then save the QC'd result
+docker run --rm -v /path/to/data:/data getwilds/gwaslab:latest \
+  python -c "
+import gwaslab as gl
+sumstats = gl.Sumstats('/data/sumstats.tsv.gz',
+                        snpid='SNP', chrom='CHR', pos='POS',
+                        ea='EA', nea='NEA', beta='BETA', se='SE',
+                        p='P', build='38')
+sumstats.basic_check()
+sumstats.to_csv('/data/sumstats_qc.tsv.gz', sep='\t')
+"
+
+# Example 3: Generate a Manhattan and QQ plot from a script mounted into the container
+docker run --rm -v /path/to/data:/data -v /path/to/script:/script getwilds/gwaslab:latest \
+  python /script/plot_manhattan.py
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/gwaslab:latest \
+  python -c "import gwaslab as gl; print(gl.__version__)"
+
+# ... or a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data gwaslab_latest.sif \
+  python /script/plot_manhattan.py
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Python 3.12 slim as the base image
+2. Adds metadata labels for documentation and attribution
+3. Installs GWASLab and its dependencies via pip with a pinned version
+4. Verifies the installation by importing the package and printing its version
+5. Uses `--no-cache-dir` to minimize image size
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/gwaslab), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.

--- a/gwaslab/README.md
+++ b/gwaslab/README.md
@@ -96,9 +96,10 @@ The Dockerfile follows these main steps:
 
 1. Uses Python 3.12 slim as the base image
 2. Adds metadata labels for documentation and attribution
-3. Installs GWASLab and its dependencies via pip with a pinned version
-4. Verifies the installation by importing the package and printing its version
-5. Uses `--no-cache-dir` to minimize image size
+3. Temporarily installs `build-essential` so pip can compile dependencies without prebuilt wheels for the target platform (e.g. scikit-allel on arm64)
+4. Installs GWASLab and its dependencies via pip with a pinned version
+5. Verifies the installation by importing the package and printing its version
+6. Removes `build-essential` and apt caches to keep the image minimal
 
 ## Security Scanning and CVEs
 


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new Docker image for [GWASLab](https://cloufield.github.io/gwaslab/), a Python-based toolkit for loading, processing, quality controlling, visualizing, and analyzing GWAS (genome-wide association study) summary statistics.

- **Version packaged:** 4.2.1 (latest stable release on PyPI)
- **Base image:** `python:3.12-slim`
- **Installation method:** `pip install gwaslab==4.2.1`, which pulls in its full dependency stack automatically (pandas, numpy, scipy, matplotlib, seaborn, pysam, polars, dask, scikit-allel, etc.)

A pure Python base was chosen over conda/miniforge since GWASLab is distributed purely via PyPI with prebuilt wheels for all its dependencies, keeping the image simpler and smaller than a full conda environment. Both `Dockerfile_latest` and `Dockerfile_4.2.1` are included (identical apart from the version label) along with a full `README.md` covering usage, citation, and example commands.

Potentially of use to a researcher in the Sinnott-Armstrong Lab: https://fhdata.slack.com/archives/CD3HGJHJT/p1785365336848339

## Testing

**How did you test these changes?**
- `make lint IMAGE=gwaslab` (hadolint)
- `make build IMAGE=gwaslab`
- Manually ran the smoke test inside the built image: `python -c "import gwaslab as gl; print(gl.__version__)"`

**Did the tests pass?**
Yes. Hadolint reported no warnings or errors. Both `Dockerfile_latest` and `Dockerfile_4.2.1` built successfully for both amd64 and arm64, and the smoke test correctly printed `4.2.1`.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)