### PR TITLE
Adding initial version of `scran` WILDS Docker image

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -17,6 +17,7 @@ popv
 python-dl
 rmats-turbo
 rtorch
+scran
 scvi-tools
 seurat
 shapemapper

--- a/scran/CVEs_1.40.0.md
+++ b/scran/CVEs_1.40.0.md
@@ -1,0 +1,56 @@
+# Vulnerability Report for getwilds/scran:1.40.0
+
+Report generated on 2026-08-06 04:22:11 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 214 |
+| 🟡 Medium | 2140 |
+| 🟢 Low | 310 |
+| ⚪ Unknown | 2 |
+
+## 🐳 Base Image
+
+**Image:** `bioconductor/bioconductor:3.23`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 214 |
+| 🟡 Medium | 2140 |
+| 🟢 Low | 308 |
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target     │  getwilds/scran:1.40.0   │   16C   214H   2140M   310L     2?  
+   digest   │  0be99e314f48                    │                                     
+ Base image │  bioconductor/bioconductor:3.23  │   16C   214H   2140M   308L     2?  
+
+Policy status  FAILED  (3/7 policies met)
+Health score  D  (50%)
+
+ Status │                     Policy                     │           Results           
+────────┼────────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                    │                             
+ !      │ Copyleft licensed packages found               │    3079 packages            
+ !      │ Fixable critical or high vulnerabilities found │   16C   174H     0M     0L  
+ ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                        │                             
+ ✓      │ No unapproved base images                      │    0 deviations             
+ !      │ Required supply chain attestations missing     │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/scran:1.40.0
+    View vulnerabilities → docker scout cves getwilds/scran:1.40.0
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/scran:1.40.0
+```
+</details>

--- a/scran/CVEs_1.40.0.md
+++ b/scran/CVEs_1.40.0.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/scran:1.40.0
 
-Report generated on 2026-08-06 04:22:11 PST
+Report generated on 2026-08-06 22:27:59 PST
 
 ## Platform Coverage
 
@@ -12,7 +12,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 |----------|-------|
 | 🔴 Critical | 16 |
 | 🟠 High | 214 |
-| 🟡 Medium | 2140 |
+| 🟡 Medium | 2160 |
 | 🟢 Low | 310 |
 | ⚪ Unknown | 2 |
 
@@ -24,29 +24,29 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 |----------|-------|
 | 🔴 Critical | 16 |
 | 🟠 High | 214 |
-| 🟡 Medium | 2140 |
+| 🟡 Medium | 2160 |
 | 🟢 Low | 308 |
 
 <details>
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target     │  getwilds/scran:1.40.0   │   16C   214H   2140M   310L     2?  
-   digest   │  0be99e314f48                    │                                     
- Base image │  bioconductor/bioconductor:3.23  │   16C   214H   2140M   308L     2?  
+Target     │  getwilds/scran:1.40.0   │   16C   214H   2160M   310L     2?  
+   digest   │  1eae6236dc56                    │                                     
+ Base image │  bioconductor/bioconductor:3.23  │   16C   214H   2160M   308L     2?  
 
-Policy status  FAILED  (3/7 policies met)
-Health score  D  (50%)
+Policy status  FAILED  (2/7 policies met, 3 missing data)
+Health score  E  (28%)
 
- Status │                     Policy                     │           Results           
-────────┼────────────────────────────────────────────────┼─────────────────────────────
- !      │ Image runs as the root user                    │                             
- !      │ Copyleft licensed packages found               │    3079 packages            
- !      │ Fixable critical or high vulnerabilities found │   16C   174H     0M     0L  
- ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
- ✓      │ No outdated base images                        │                             
- ✓      │ No unapproved base images                      │    0 deviations             
- !      │ Required supply chain attestations missing     │    2 deviations             
+ Status │                   Policy                   │     Results     
+────────┼────────────────────────────────────────────┼─────────────────
+ !      │ Image runs as the root user                │                 
+ ?      │ No data                                    │    No data      
+ ?      │ No data                                    │    No data      
+ ?      │ No data                                    │    No data      
+ ✓      │ No outdated base images                    │                 
+ ✓      │ No unapproved base images                  │    0 deviations 
+ !      │ Required supply chain attestations missing │    2 deviations 
 
 What's next:
     View policy violations → docker scout policy getwilds/scran:1.40.0

--- a/scran/CVEs_latest.md
+++ b/scran/CVEs_latest.md
@@ -1,0 +1,56 @@
+# Vulnerability Report for getwilds/scran:latest
+
+Report generated on 2026-08-06 04:32:22 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 214 |
+| 🟡 Medium | 2140 |
+| 🟢 Low | 310 |
+| ⚪ Unknown | 2 |
+
+## 🐳 Base Image
+
+**Image:** `bioconductor/bioconductor:3.23`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 16 |
+| 🟠 High | 214 |
+| 🟡 Medium | 2140 |
+| 🟢 Low | 308 |
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target     │  getwilds/scran:latest   │   16C   214H   2140M   310L     2?  
+   digest   │  46abe80b4d39                    │                                     
+ Base image │  bioconductor/bioconductor:3.23  │   16C   214H   2140M   308L     2?  
+
+Policy status  FAILED  (3/7 policies met)
+Health score  D  (50%)
+
+ Status │                     Policy                     │           Results           
+────────┼────────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                    │                             
+ !      │ Copyleft licensed packages found               │    3079 packages            
+ !      │ Fixable critical or high vulnerabilities found │   16C   174H     0M     0L  
+ ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                        │                             
+ ✓      │ No unapproved base images                      │    0 deviations             
+ !      │ Required supply chain attestations missing     │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/scran:latest
+    View vulnerabilities → docker scout cves getwilds/scran:latest
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/scran:latest
+```
+</details>

--- a/scran/CVEs_latest.md
+++ b/scran/CVEs_latest.md
@@ -1,6 +1,6 @@
 # Vulnerability Report for getwilds/scran:latest
 
-Report generated on 2026-08-06 04:32:22 PST
+Report generated on 2026-08-06 22:38:53 PST
 
 ## Platform Coverage
 
@@ -12,7 +12,7 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 |----------|-------|
 | 🔴 Critical | 16 |
 | 🟠 High | 214 |
-| 🟡 Medium | 2140 |
+| 🟡 Medium | 2160 |
 | 🟢 Low | 310 |
 | ⚪ Unknown | 2 |
 
@@ -24,16 +24,16 @@ This vulnerability scan covers the **linux/amd64** platform. While this image al
 |----------|-------|
 | 🔴 Critical | 16 |
 | 🟠 High | 214 |
-| 🟡 Medium | 2140 |
+| 🟡 Medium | 2160 |
 | 🟢 Low | 308 |
 
 <details>
 <summary>📋 Raw Docker Scout Output</summary>
 
 ```text
-Target     │  getwilds/scran:latest   │   16C   214H   2140M   310L     2?  
-   digest   │  46abe80b4d39                    │                                     
- Base image │  bioconductor/bioconductor:3.23  │   16C   214H   2140M   308L     2?  
+Target     │  getwilds/scran:latest   │   16C   214H   2160M   310L     2?  
+   digest   │  5b843cf51c2d                    │                                     
+ Base image │  bioconductor/bioconductor:3.23  │   16C   214H   2160M   308L     2?  
 
 Policy status  FAILED  (3/7 policies met)
 Health score  D  (50%)
@@ -41,7 +41,7 @@ Health score  D  (50%)
  Status │                     Policy                     │           Results           
 ────────┼────────────────────────────────────────────────┼─────────────────────────────
  !      │ Image runs as the root user                    │                             
- !      │ Copyleft licensed packages found               │    3079 packages            
+ !      │ Copyleft licensed packages found               │    3068 packages            
  !      │ Fixable critical or high vulnerabilities found │   16C   174H     0M     0L  
  ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
  ✓      │ No outdated base images                        │                             

--- a/scran/Dockerfile_1.40.0
+++ b/scran/Dockerfile_1.40.0
@@ -1,0 +1,26 @@
+# Use Bioconductor base image
+FROM bioconductor/bioconductor_docker:RELEASE_3_23
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="scran"
+LABEL org.opencontainers.image.description="Docker image for scran single-cell RNA-seq analysis in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="1.40.0"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install scran and commonly used companion packages, then smoke test
+RUN R -e "BiocManager::install(c('scran', 'scater', 'scuttle', 'SingleCellExperiment'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
+  && R -e "library(scran); stopifnot(packageVersion('scran') == '1.40.0')"
+
+# Set working directory
+WORKDIR /data

--- a/scran/Dockerfile_1.40.0
+++ b/scran/Dockerfile_1.40.0
@@ -18,8 +18,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV R_LIBS_USER=/usr/local/lib/R/site-library
 ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
 
-# Install scran and commonly used companion packages, then smoke test
-RUN R -e "BiocManager::install(c('scran', 'scater', 'scuttle', 'SingleCellExperiment'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
+# Install scran, then smoke test
+RUN R -e "BiocManager::install('scran', update=FALSE, ask=FALSE, dependencies=TRUE)" \
   && R -e "library(scran); stopifnot(packageVersion('scran') == '1.40.0')"
 
 # Set working directory

--- a/scran/Dockerfile_latest
+++ b/scran/Dockerfile_latest
@@ -1,0 +1,26 @@
+# Use Bioconductor base image
+FROM bioconductor/bioconductor_docker:RELEASE_3_23
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="scran"
+LABEL org.opencontainers.image.description="Docker image for scran single-cell RNA-seq analysis in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+# Set the shell option to fail if any command in a pipe fails
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+# Install scran and commonly used companion packages, then smoke test
+RUN R -e "BiocManager::install(c('scran', 'scater', 'scuttle', 'SingleCellExperiment'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
+  && R -e "library(scran); packageVersion('scran')"
+
+# Set working directory
+WORKDIR /data

--- a/scran/Dockerfile_latest
+++ b/scran/Dockerfile_latest
@@ -18,8 +18,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV R_LIBS_USER=/usr/local/lib/R/site-library
 ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
 
-# Install scran and commonly used companion packages, then smoke test
-RUN R -e "BiocManager::install(c('scran', 'scater', 'scuttle', 'SingleCellExperiment'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
+# Install scran, then smoke test
+RUN R -e "BiocManager::install('scran', update=FALSE, ask=FALSE, dependencies=TRUE)" \
   && R -e "library(scran); packageVersion('scran')"
 
 # Set working directory

--- a/scran/README.md
+++ b/scran/README.md
@@ -1,0 +1,119 @@
+# scran
+
+This directory contains Docker images for scran, a Bioconductor package providing methods for the analysis of single-cell RNA-seq data, including normalization, highly variable gene detection, and clustering support.
+
+## Available Versions
+
+- `latest` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/scran/Dockerfile_latest) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/scran/CVEs_latest.md) )
+- `1.40.0` ( [Dockerfile](https://github.com/getwilds/wilds-docker-library/blob/main/scran/Dockerfile_1.40.0) | [Vulnerability Report](https://github.com/getwilds/wilds-docker-library/blob/main/scran/CVEs_1.40.0.md) )
+
+## Image Details
+
+These Docker images are built from the Bioconductor base image (RELEASE_3_23) and include:
+
+- scran v1.40.0: Deconvolution-based normalization, highly variable gene (HVG) detection, quick clustering, marker gene identification, and doublet detection for single-cell RNA-seq data
+- scater: Quality control and visualization for single-cell data, commonly used alongside scran
+- scuttle: Utility functions for single-cell data handling (a hard dependency of scran)
+- SingleCellExperiment: The core data container class used throughout the Bioconductor single-cell ecosystem
+
+The images are designed to provide a focused environment for single-cell RNA-seq preprocessing and normalization with scran and its most common companion tools. Note that Bioconductor documents scran as being in a transitional state, with much of its functionality being superseded by the newer `scrapper` package, though scran remains fully installable and functional.
+
+## Platform Availability
+
+**Note:** This image is only built for **linux/amd64** architecture. scran and its C++ dependencies have compilation issues on ARM64 platforms.
+
+## Citation
+
+If you use scran in your research, please cite the original authors:
+
+```
+Lun ATL, McCarthy DJ, Marioni JC (2016). A step-by-step workflow for
+low-level analysis of single-cell RNA-seq data with Bioconductor.
+F1000Research, 5, 2122. https://doi.org/10.12688/f1000research.9501.2
+```
+
+**Tool homepage:** https://bioconductor.org/packages/release/bioc/html/scran.html
+
+## Usage
+
+### Docker
+
+```bash
+# Pull the latest version
+docker pull getwilds/scran:latest
+
+# Or pull a specific version
+docker pull getwilds/scran:1.40.0
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/scran:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+# Pull the latest version
+apptainer pull docker://getwilds/scran:latest
+
+# Or pull a specific version
+apptainer pull docker://getwilds/scran:1.40.0
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/scran:latest
+```
+
+### Example Commands
+
+```bash
+# Launch an interactive R session with scran loaded
+docker run --rm -it -v /path/to/data:/data getwilds/scran:latest R
+
+# Run an R script that performs a scran normalization/HVG workflow
+docker run --rm -v /path/to/data:/data getwilds/scran:latest \
+  Rscript /data/scran_analysis.R
+
+# Run a quick inline scran workflow on a saved SingleCellExperiment object
+docker run --rm -v /path/to/data:/data getwilds/scran:latest R -e "
+  library(scran)
+  library(scuttle)
+  sce <- readRDS('/data/sce.rds')
+  clusters <- quickCluster(sce)
+  sce <- computeSumFactors(sce, clusters = clusters)
+  sce <- logNormCounts(sce)
+  dec <- modelGeneVar(sce)
+  top_hvgs <- getTopHVGs(dec, n = 2000)
+  saveRDS(sce, '/data/sce_normalized.rds')
+  writeLines(top_hvgs, '/data/top_hvgs.txt')
+"
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/scran:latest \
+  Rscript /data/scran_analysis.R
+
+# Or a local SIF file via Apptainer
+apptainer run --bind /path/to/data:/data scran_latest.sif \
+  Rscript /data/scran_analysis.R
+```
+
+## Dockerfile Structure
+
+The Dockerfile follows these main steps:
+
+1. Uses Bioconductor RELEASE_3_23 as the base image
+2. Adds metadata labels for documentation and attribution
+3. Sets R library paths to prevent host library contamination in Apptainer
+4. Installs scran, scater, scuttle, and SingleCellExperiment via BiocManager
+5. Runs a smoke test to confirm scran loads and reports its version
+6. Sets `/data` as the default working directory
+
+## Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the nature of bioinformatics software and their dependencies, some Docker images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about this image, please check the `CVEs_*.md` files in [this directory](https://github.com/getwilds/wilds-docker-library/blob/main/scran), which are automatically updated through our GitHub Actions workflow. If a particular vulnerability is of concern, please file an [issue](https://github.com/getwilds/wilds-docker-library/issues) in the GitHub repo citing which CVE you would like to be addressed.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository.

--- a/scran/README.md
+++ b/scran/README.md
@@ -12,11 +12,10 @@ This directory contains Docker images for scran, a Bioconductor package providin
 These Docker images are built from the Bioconductor base image (RELEASE_3_23) and include:
 
 - scran v1.40.0: Deconvolution-based normalization, highly variable gene (HVG) detection, quick clustering, marker gene identification, and doublet detection for single-cell RNA-seq data
-- scater: Quality control and visualization for single-cell data, commonly used alongside scran
-- scuttle: Utility functions for single-cell data handling (a hard dependency of scran)
-- SingleCellExperiment: The core data container class used throughout the Bioconductor single-cell ecosystem
 
-The images are designed to provide a focused environment for single-cell RNA-seq preprocessing and normalization with scran and its most common companion tools. Note that Bioconductor documents scran as being in a transitional state, with much of its functionality being superseded by the newer `scrapper` package, though scran remains fully installable and functional.
+The images are designed to provide a minimal, focused environment for single-cell RNA-seq preprocessing and normalization with scran itself. Note that Bioconductor documents scran as being in a transitional state, with much of its functionality being superseded by the newer `scrapper` package, though scran remains fully installable and functional.
+
+For quality control and visualization of single-cell data (commonly used alongside scran), see the separate [scater image](https://github.com/getwilds/wilds-docker-library/tree/main/scater).
 
 ## Platform Availability
 
@@ -75,7 +74,6 @@ docker run --rm -v /path/to/data:/data getwilds/scran:latest \
 # Run a quick inline scran workflow on a saved SingleCellExperiment object
 docker run --rm -v /path/to/data:/data getwilds/scran:latest R -e "
   library(scran)
-  library(scuttle)
   sce <- readRDS('/data/sce.rds')
   clusters <- quickCluster(sce)
   sce <- computeSumFactors(sce, clusters = clusters)
@@ -102,7 +100,7 @@ The Dockerfile follows these main steps:
 1. Uses Bioconductor RELEASE_3_23 as the base image
 2. Adds metadata labels for documentation and attribution
 3. Sets R library paths to prevent host library contamination in Apptainer
-4. Installs scran, scater, scuttle, and SingleCellExperiment via BiocManager
+4. Installs scran via BiocManager
 5. Runs a smoke test to confirm scran loads and reports its version
 6. Sets `/data` as the default working directory
 


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new Docker image for [scran](https://bioconductor.org/packages/release/bioc/html/scran.html), a Bioconductor package providing methods for single-cell RNA-seq analysis, including deconvolution-based normalization, highly variable gene (HVG) detection, quick clustering, marker gene identification, and doublet detection.

- **Version packaged:** scran v1.40.0
- **Base image:** `bioconductor/bioconductor_docker:RELEASE_3_23`
- **Installation method:** `BiocManager::install()`, alongside the common companion packages `scater`, `scuttle`, and `SingleCellExperiment` that are typically used together in single-cell workflows
- Added `scran` to `amd64_only_tools.txt`, since scran and its C++ dependencies have known compilation issues on ARM64 (consistent with how `edger` and `deseq2` are handled on the same base image)

## Related Issue

https://github.com/getwilds/wilds-wdl-library/issues/333

## Testing

**How did you test these changes?**
Ran `make lint IMAGE=scran` and `make build_amd64 IMAGE=scran`.

**Did the tests pass?**
Yes.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [x] Image builds successfully for target platform(s)