### PR TITLE
Adding initial version of Hades WILDS Docker image

### DIFF
--- a/amd64_only_tools.txt
+++ b/amd64_only_tools.txt
@@ -9,6 +9,7 @@ diamond
 esmfold
 glimpse2
 flax
+hades
 hisat2
 manta
 megahit

--- a/hades/CVEs_full.md
+++ b/hades/CVEs_full.md
@@ -1,0 +1,56 @@
+# Vulnerability Report for getwilds/hades:full
+
+Report generated on 2026-08-18 17:30:09 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 4 |
+| 🟠 High | 169 |
+| 🟡 Medium | 1988 |
+| 🟢 Low | 131 |
+| ⚪ Unknown | 2 |
+
+## 🐳 Base Image
+
+**Image:** `oisupport/staging-amd64:24.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 5 |
+| 🟢 Low | 4 |
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target     │  getwilds/hades:full    │    4C   169H   1988M   131L     2?  
+   digest   │  a760d4d7baa0                   │                                     
+ Base image │  oisupport/staging-amd64:24.04  │    0C     0H     5M     4L          
+
+Policy status  FAILED  (3/7 policies met)
+Health score  D  (50%)
+
+ Status │                     Policy                     │           Results           
+────────┼────────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                    │                             
+ !      │ Copyleft licensed packages found               │    1506 packages            
+ !      │ Fixable critical or high vulnerabilities found │    4C   127H     0M     0L  
+ ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                        │                             
+ ✓      │ No unapproved base images                      │    0 deviations             
+ !      │ Required supply chain attestations missing     │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/hades:full
+    View vulnerabilities → docker scout cves getwilds/hades:full
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/hades:full
+```
+</details>

--- a/hades/CVEs_latest.md
+++ b/hades/CVEs_latest.md
@@ -1,0 +1,56 @@
+# Vulnerability Report for getwilds/hades:latest
+
+Report generated on 2026-08-18 17:50:58 PST
+
+## Platform Coverage
+
+This vulnerability scan covers the **linux/amd64** platform. While this image also supports linux/arm64, the security analysis focuses on the AMD64 variant as it represents the majority of deployment targets. Vulnerabilities between architectures are typically similar for most bioinformatics applications.
+
+## 📊 Vulnerability Summary
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 4 |
+| 🟠 High | 169 |
+| 🟡 Medium | 1987 |
+| 🟢 Low | 131 |
+| ⚪ Unknown | 2 |
+
+## 🐳 Base Image
+
+**Image:** `oisupport/staging-amd64:24.04`
+
+| Severity | Count |
+|----------|-------|
+| 🔴 Critical | 0 |
+| 🟠 High | 0 |
+| 🟡 Medium | 5 |
+| 🟢 Low | 4 |
+
+<details>
+<summary>📋 Raw Docker Scout Output</summary>
+
+```text
+Target     │  getwilds/hades:latest  │    4C   169H   1987M   131L     2?  
+   digest   │  1a288a7cdf71                   │                                     
+ Base image │  oisupport/staging-amd64:24.04  │    0C     0H     5M     4L          
+
+Policy status  FAILED  (3/7 policies met)
+Health score  D  (50%)
+
+ Status │                     Policy                     │           Results           
+────────┼────────────────────────────────────────────────┼─────────────────────────────
+ !      │ Image runs as the root user                    │                             
+ !      │ Copyleft licensed packages found               │    1506 packages            
+ !      │ Fixable critical or high vulnerabilities found │    4C   127H     0M     0L  
+ ✓      │ No high-profile vulnerabilities                │    0C     0H     0M     0L  
+ ✓      │ No outdated base images                        │                             
+ ✓      │ No unapproved base images                      │    0 deviations             
+ !      │ Required supply chain attestations missing     │    2 deviations             
+
+What's next:
+    View policy violations → docker scout policy getwilds/hades:latest
+    View vulnerabilities → docker scout cves getwilds/hades:latest
+    Compare with the latest in the registry → docker scout compare --to-latest getwilds/hades:latest
+```
+</details>

--- a/hades/Dockerfile_full
+++ b/hades/Dockerfile_full
@@ -6,11 +6,13 @@
 # Databricks cluster runtime and package mirror used in production. For a
 # lighter, non-Databricks-specific HADES image, see Dockerfile_latest.
 #
-# Apple Silicon build:
+# Apple Silicon build (from the repository root, since COPY sources are
+# rooted there):
 #
 #   docker buildx build \
 #     --platform linux/amd64 \
 #     -t getwilds/hades:full \
+#     -f hades/Dockerfile_full \
 #     --load \
 #     .
 #
@@ -210,7 +212,7 @@ ARG RENV_INSTALL_TIMEOUT=21600
 ENV CRAN_REPO=${CRAN_REPO} \
     RENV_INSTALL_TIMEOUT=${RENV_INSTALL_TIMEOUT}
 
-COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
+COPY hades/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 #------------------------------------------------------------------------------
 # 7. Install renv
@@ -232,7 +234,7 @@ WORKDIR /opt/ohdsi/hades
 # 9. Copy the pinned HADES-wide release lockfile
 #------------------------------------------------------------------------------
 
-COPY renv.lock /opt/ohdsi/hades/renv.lock
+COPY hades/renv.lock /opt/ohdsi/hades/renv.lock
 
 #------------------------------------------------------------------------------
 # 10. Verify the lockfile and R version
@@ -255,7 +257,7 @@ RUN R -e " \
 # mount existing.
 #------------------------------------------------------------------------------
 
-COPY install-hades.R /opt/ohdsi/hades/install-hades.R
+COPY hades/install-hades.R /opt/ohdsi/hades/install-hades.R
 
 RUN --mount=type=cache,target=/opt/renv,sharing=locked \
     RENV_PATHS_ROOT=/opt/renv \
@@ -281,7 +283,7 @@ RUN R -e "install.packages(c('hwriter', 'TeachingDemos'))" && \
 # 13. Copy validation script
 #------------------------------------------------------------------------------
 
-COPY validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
+COPY hades/validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
 
 #------------------------------------------------------------------------------
 # 14. Validate the OHDSI/HADES environment (smoke test)

--- a/hades/Dockerfile_full
+++ b/hades/Dockerfile_full
@@ -1,0 +1,304 @@
+# syntax=docker/dockerfile:1
+#==============================================================================
+# Databricks Runtime 17.3 LTS + OHDSI HADES 2026Q1
+#
+# Full-parity build of the HADES 2026Q1 release on top of the same
+# Databricks cluster runtime and package mirror used in production. For a
+# lighter, non-Databricks-specific HADES image, see Dockerfile_latest.
+#
+# Apple Silicon build:
+#
+#   docker buildx build \
+#     --platform linux/amd64 \
+#     -t getwilds/hades:full \
+#     --load \
+#     .
+#
+# Prefer an amd64 builder where one is available. Under QEMU every package
+# that is not available as a binary is compiled through emulation, which is
+# what pushes the restore past renv's install deadline.
+#
+# The lockfile pulls 16 packages from github.com/ohdsi. Anonymous GitHub API
+# access is capped at 60 requests/hour; renv needs it to resolve each
+# remote's dependencies, but 16 lookups comfortably fits that limit.
+#
+# Packages come from the Databricks Posit Package Manager mirror (same host
+# DBR uses for cluster installs). DBR 17.3 LTS freezes CRAN at 2025-03-20;
+# this image defaults to 2026-03-23 so the HADES 2026Q1 lockfile can install
+# as binaries instead of compiling.
+#
+#   # Match DBR 17.3 LTS freeze (many HADES pins will build from source):
+#   --build-arg PPM_SNAPSHOT=2025-03-20
+#
+#   # Public Posit fallback if the Databricks host is unreachable:
+#   --build-arg PPM_HOST=https://p3m.dev
+#
+# Build args: PPM_HOST, PPM_DISTRO, PPM_SNAPSHOT, CRAN_REPO,
+#             RENV_INSTALL_JOBS, RENV_INSTALL_TIMEOUT.
+#==============================================================================
+
+FROM databricksruntime/standard:17.3-LTS
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="hades"
+LABEL org.opencontainers.image.description="Databricks-parity image for OHDSI HADES 2026Q1 in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="full"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+#------------------------------------------------------------------------------
+# 1. Install build/runtime dependencies
+#------------------------------------------------------------------------------
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        wget \
+        git \
+        build-essential \
+        gcc \
+        g++ \
+        gfortran \
+        make \
+        cmake \
+        perl \
+        xz-utils \
+        bzip2 \
+        pkg-config \
+        unixodbc \
+        unixodbc-dev \
+        odbcinst \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libxml2-dev \
+        libgit2-dev \
+        libicu-dev \
+        libbz2-dev \
+        liblzma-dev \
+        zlib1g-dev \
+        libreadline-dev \
+        libncurses-dev \
+        libncurses5-dev \
+        libncursesw5-dev \
+        libtinfo-dev \
+        libpcre2-dev \
+        libx11-dev \
+        libxt-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libtiff-dev \
+        libcairo2-dev \
+        libfontconfig1-dev \
+        libfreetype6-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        # Runtime BLAS/LAPACK for PPM binaries (e.g. Matrix.so needs liblapack.so.3)
+        libblas3 \
+        liblapack3 \
+        libopenblas0 \
+        libgomp1 \
+        # Common PPM binary runtime deps for HADES stack
+        libgfortran5 \
+        libnode109 \
+        libsqlite3-0 \
+        libsecret-1-0 \
+        libnlopt0 \
+        libgit2-1.7 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Validate ODBC:
+RUN odbcinst -j && \
+    test -f /usr/include/sql.h
+
+# Validate BLAS/LAPACK (required by PPM binaries such as Matrix):
+RUN ldconfig -p | grep -E 'lib(lapack|blas|openblas)\.so' && \
+    test -e /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/liblapack.so.3
+
+# Validate full Java JDK:
+RUN java -version && \
+    javac -version
+
+#------------------------------------------------------------------------------
+# 2. Configure CRAN repository for Ubuntu 24.04
+#------------------------------------------------------------------------------
+
+RUN mkdir -p /etc/apt/keyrings && \
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 \
+        --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+    gpg --export E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+        > /etc/apt/keyrings/cran.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/cran.gpg] https://cloud.r-project.org/bin/linux/ubuntu noble-cran40/" \
+        > /etc/apt/sources.list.d/cran-r.list
+
+#------------------------------------------------------------------------------
+# 3. Install R 4.4.1
+#
+# Match OHDSI HADES recommended R version.
+#------------------------------------------------------------------------------
+
+ARG R_VERSION=4.4.1
+
+WORKDIR /tmp
+
+RUN curl -fsSL \
+    https://cran.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz \
+    -o R-${R_VERSION}.tar.gz && \
+    tar -xzf R-${R_VERSION}.tar.gz && \
+    cd R-${R_VERSION} && \
+    ./configure \
+        --prefix=/usr/local \
+        --enable-R-shlib \
+        --with-x \
+        --with-blas \
+        --with-lapack && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd / && \
+    rm -rf \
+        /tmp/R-${R_VERSION} \
+        /tmp/R-${R_VERSION}.tar.gz
+
+#------------------------------------------------------------------------------
+# 4. Validate R and Java
+#------------------------------------------------------------------------------
+
+RUN echo "===== R VERSION =====" && \
+    R --version && \
+    R -e 'stopifnot(getRversion() == "4.4.1")'
+
+RUN echo "===== JAVA VERSION =====" && \
+    java -version
+
+#------------------------------------------------------------------------------
+# 5. Configure R <-> Java
+#------------------------------------------------------------------------------
+
+RUN _JAVA_OPTIONS="-Xmx4g" R CMD javareconf
+
+#------------------------------------------------------------------------------
+# 6. Configure R package defaults
+#
+# CRAN_REPO points at Databricks' Posit Package Manager binary URL for
+# Ubuntu noble. Pins missing from that snapshot fall through to
+# cloud.r-project.org (see RENV_CONFIG_REPOS_OVERRIDE below).
+#
+# RENV_INSTALL_TIMEOUT is the deadline renv applies to the *entire* install
+# phase, not to individual packages. renv defaults to 3600 seconds, which
+# this lockfile overruns under QEMU/source builds.
+#------------------------------------------------------------------------------
+
+ARG PPM_HOST=https://databricks.packagemanager.posit.co
+ARG PPM_DISTRO=noble
+# DBR 17.3 LTS freezes at 2025-03-20. Default is later so HADES 2026Q1
+# pins install as binaries from the same Databricks PPM host.
+ARG PPM_SNAPSHOT=2026-03-23
+ARG CRAN_REPO=${PPM_HOST}/cran/__linux__/${PPM_DISTRO}/${PPM_SNAPSHOT}
+ARG RENV_INSTALL_JOBS=4
+ARG RENV_INSTALL_TIMEOUT=21600
+
+ENV CRAN_REPO=${CRAN_REPO} \
+    RENV_INSTALL_TIMEOUT=${RENV_INSTALL_TIMEOUT}
+
+COPY Rprofile.site /usr/local/lib/R/etc/Rprofile.site
+
+#------------------------------------------------------------------------------
+# 7. Install renv
+#------------------------------------------------------------------------------
+
+RUN R -e "install.packages(c('renv', 'jsonlite'))" && \
+    R -e "stopifnot( \
+        requireNamespace('renv', quietly = TRUE), \
+        requireNamespace('jsonlite', quietly = TRUE) \
+    )"
+
+#------------------------------------------------------------------------------
+# 8. Create HADES environment
+#------------------------------------------------------------------------------
+
+WORKDIR /opt/ohdsi/hades
+
+#------------------------------------------------------------------------------
+# 9. Copy the pinned HADES-wide release lockfile
+#------------------------------------------------------------------------------
+
+COPY renv.lock /opt/ohdsi/hades/renv.lock
+
+#------------------------------------------------------------------------------
+# 10. Verify the lockfile and R version
+#------------------------------------------------------------------------------
+
+RUN R -e " \
+    lock <- jsonlite::read_json('/opt/ohdsi/hades/renv.lock'); \
+    cat('HADES lockfile R version:', lock\$R\$Version, '\n'); \
+    cat('Container R version:', as.character(getRversion()), '\n'); \
+    stopifnot(lock\$R\$Version == '4.4.1'); \
+    stopifnot(as.character(getRversion()) == '4.4.1') \
+    "
+
+#------------------------------------------------------------------------------
+# 11. Restore HADES-wide dependency snapshot
+#
+# renv's cache and downloaded sources live in a build cache mount so a retry
+# does not start from an empty cache. Cache symlinks are off so restored
+# packages are copied into the library and the image does not depend on that
+# mount existing.
+#------------------------------------------------------------------------------
+
+COPY install-hades.R /opt/ohdsi/hades/install-hades.R
+
+RUN --mount=type=cache,target=/opt/renv,sharing=locked \
+    RENV_PATHS_ROOT=/opt/renv \
+    RENV_CONFIG_CACHE_SYMLINKS=FALSE \
+    RENV_CONFIG_REPOS_OVERRIDE="CRAN=${CRAN_REPO};FALLBACK=https://cloud.r-project.org" \
+    RENV_CONFIG_INSTALL_JOBS="${RENV_INSTALL_JOBS}" \
+    Rscript /opt/ohdsi/hades/install-hades.R
+
+#------------------------------------------------------------------------------
+# 12. Reconfigure Java after package restore
+#------------------------------------------------------------------------------
+
+RUN R CMD javareconf
+
+# Packages Databricks requires to start an R REPL in notebooks.
+# Rserve backs the driver's R connection; hwriterPlus renders cell output.
+RUN R -e "install.packages(c('hwriter', 'TeachingDemos'))" && \
+    R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/hwriterPlus/hwriterPlus_1.0-3.tar.gz', repos = NULL, type = 'source')" && \
+    R -e "install.packages('Rserve', repos = 'http://rforge.net/')" && \
+    R -e "stopifnot(nzchar(system.file(package = 'Rserve')), nzchar(system.file(package = 'hwriterPlus')))"
+
+#------------------------------------------------------------------------------
+# 13. Copy validation script
+#------------------------------------------------------------------------------
+
+COPY validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
+
+#------------------------------------------------------------------------------
+# 14. Validate the OHDSI/HADES environment (smoke test)
+#------------------------------------------------------------------------------
+
+RUN _JAVA_OPTIONS="-Xmx4g" Rscript /opt/ohdsi/hades/validate-ohdsi.R
+
+#------------------------------------------------------------------------------
+# 15. Final environment info
+#------------------------------------------------------------------------------
+
+RUN echo "===================================" && \
+    echo "Final OHDSI / Databricks environment" && \
+    echo "===================================" && \
+    R --version && \
+    java -version
+
+WORKDIR /
+
+RUN echo 'options(bitmapType = "cairo")' >> /usr/local/lib/R/etc/Rprofile.site

--- a/hades/Dockerfile_latest
+++ b/hades/Dockerfile_latest
@@ -2,22 +2,27 @@
 # OHDSI HADES 2026Q1 (lightweight)
 #
 # A pared-down build of the HADES 2026Q1 release: same pinned package set as
-# Dockerfile_full (renv.lock), but on a standard R base image instead of the
-# Databricks cluster runtime, and without the from-source R build, the
-# Databricks Posit Package Manager mirror, or the notebook/Rserve glue those
-# require. Use this image for local HADES analyses; use Dockerfile_full when
-# you need parity with a specific Databricks cluster.
+# Dockerfile_full (renv.lock), installed as binaries from the public Posit
+# Package Manager mirror rather than the Databricks-hosted one. Runs on a
+# standard R base image instead of the Databricks cluster runtime, and skips
+# the from-source R build and the notebook/Rserve glue Dockerfile_full needs
+# for Databricks parity. Use this image for local HADES analyses; use
+# Dockerfile_full when you need parity with a specific Databricks cluster.
 #
-# Build:
+# Build (from the repository root, since COPY sources are rooted there):
 #
 #   docker buildx build \
 #     --platform linux/amd64 \
 #     -t getwilds/hades:latest \
+#     -f hades/Dockerfile_latest \
 #     .
 #
 # The lockfile pulls 16 packages from github.com/ohdsi. Anonymous GitHub API
 # access is capped at 60 requests/hour; renv needs it to resolve each
 # remote's dependencies, but 16 lookups comfortably fits that limit.
+#
+# Build args: PPM_HOST, PPM_DISTRO, PPM_SNAPSHOT, CRAN_REPO,
+#             RENV_INSTALL_JOBS, RENV_INSTALL_TIMEOUT.
 #==============================================================================
 
 FROM rocker/r-ver:4.4.1
@@ -47,6 +52,11 @@ ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/libr
 # libssl for HTTP + XML packages, and libnode-dev (provides the V8 engine
 # libv8-dev is a virtual alias for) for V8/CirceR. No X11/Cairo/font
 # libraries: this image is not built for R graphics devices.
+#
+# The runtime (non-dev) libraries below are needed because CRAN_REPO serves
+# prebuilt PPM binaries, which dynamically link against these .so files
+# directly rather than compiling against the -dev packages above
+# (e.g. keyring.so needs libsecret-1.so.0, Matrix.so needs liblapack.so.3).
 #------------------------------------------------------------------------------
 
 RUN apt-get update \
@@ -58,6 +68,14 @@ RUN apt-get update \
   && LIBGIT2_VERSION=$(apt-cache policy libgit2-dev | grep Candidate | awk '{print $2}') \
   && LIBNODE_VERSION=$(apt-cache policy libnode-dev | grep Candidate | awk '{print $2}') \
   && LIBSODIUM_VERSION=$(apt-cache policy libsodium-dev | grep Candidate | awk '{print $2}') \
+  && LIBBLAS_VERSION=$(apt-cache policy libblas3 | grep Candidate | awk '{print $2}') \
+  && LIBLAPACK_VERSION=$(apt-cache policy liblapack3 | grep Candidate | awk '{print $2}') \
+  && LIBOPENBLAS_VERSION=$(apt-cache policy libopenblas0 | grep Candidate | awk '{print $2}') \
+  && LIBGOMP_VERSION=$(apt-cache policy libgomp1 | grep Candidate | awk '{print $2}') \
+  && LIBGFORTRAN_VERSION=$(apt-cache policy libgfortran5 | grep Candidate | awk '{print $2}') \
+  && LIBSQLITE3_VERSION=$(apt-cache policy libsqlite3-0 | grep Candidate | awk '{print $2}') \
+  && LIBSECRET_VERSION=$(apt-cache policy libsecret-1-0 | grep Candidate | awk '{print $2}') \
+  && LIBNLOPT_VERSION=$(apt-cache policy libnlopt0 | grep Candidate | awk '{print $2}') \
   && apt-get install -y --no-install-recommends \
   default-jdk="${DEFAULT_JDK_VERSION}" \
   unixodbc-dev="${UNIXODBC_VERSION}" \
@@ -67,6 +85,14 @@ RUN apt-get update \
   libgit2-dev="${LIBGIT2_VERSION}" \
   libnode-dev="${LIBNODE_VERSION}" \
   libsodium-dev="${LIBSODIUM_VERSION}" \
+  libblas3="${LIBBLAS_VERSION}" \
+  liblapack3="${LIBLAPACK_VERSION}" \
+  libopenblas0="${LIBOPENBLAS_VERSION}" \
+  libgomp1="${LIBGOMP_VERSION}" \
+  libgfortran5="${LIBGFORTRAN_VERSION}" \
+  libsqlite3-0="${LIBSQLITE3_VERSION}" \
+  libsecret-1-0="${LIBSECRET_VERSION}" \
+  libnlopt0="${LIBNLOPT_VERSION}" \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -75,12 +101,20 @@ RUN R CMD javareconf
 #------------------------------------------------------------------------------
 # 2. Configure R package defaults
 #
+# CRAN_REPO points at the public Posit Package Manager binary URL for Ubuntu
+# jammy (this image's base OS) so the restore installs prebuilt binaries
+# instead of compiling ~278 CRAN packages from source, the way plain
+# cloud.r-project.org would on Linux.
+#
 # RENV_INSTALL_TIMEOUT is the deadline renv applies to the *entire* install
 # phase, not to individual packages. renv defaults to 3600 seconds, which
-# this lockfile overruns once anything compiles from source.
+# this lockfile can overrun even with binaries available.
 #------------------------------------------------------------------------------
 
-ARG CRAN_REPO=https://cloud.r-project.org
+ARG PPM_HOST=https://packagemanager.posit.co
+ARG PPM_DISTRO=jammy
+ARG PPM_SNAPSHOT=latest
+ARG CRAN_REPO=${PPM_HOST}/cran/__linux__/${PPM_DISTRO}/${PPM_SNAPSHOT}
 ARG RENV_INSTALL_JOBS=4
 ARG RENV_INSTALL_TIMEOUT=21600
 
@@ -106,13 +140,13 @@ RUN R -e "install.packages(c('renv', 'jsonlite'), repos = '${CRAN_REPO}')" && \
 
 WORKDIR /opt/ohdsi/hades
 
-COPY renv.lock /opt/ohdsi/hades/renv.lock
-COPY install-hades.R /opt/ohdsi/hades/install-hades.R
+COPY hades/renv.lock /opt/ohdsi/hades/renv.lock
+COPY hades/install-hades.R /opt/ohdsi/hades/install-hades.R
 
 RUN --mount=type=cache,target=/opt/renv,sharing=locked \
     RENV_PATHS_ROOT=/opt/renv \
     RENV_CONFIG_CACHE_SYMLINKS=FALSE \
-    RENV_CONFIG_REPOS_OVERRIDE="CRAN=${CRAN_REPO}" \
+    RENV_CONFIG_REPOS_OVERRIDE="CRAN=${CRAN_REPO};FALLBACK=https://cloud.r-project.org" \
     RENV_CONFIG_INSTALL_JOBS="${RENV_INSTALL_JOBS}" \
     Rscript /opt/ohdsi/hades/install-hades.R
 
@@ -120,7 +154,7 @@ RUN --mount=type=cache,target=/opt/renv,sharing=locked \
 # 5. Validate the HADES environment (smoke test)
 #------------------------------------------------------------------------------
 
-COPY validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
+COPY hades/validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
 
 RUN Rscript /opt/ohdsi/hades/validate-ohdsi.R
 

--- a/hades/Dockerfile_latest
+++ b/hades/Dockerfile_latest
@@ -1,31 +1,50 @@
+# syntax=docker/dockerfile:1
 #==============================================================================
-# OHDSI HADES 2026Q1 (lightweight)
+# Databricks Runtime 17.3 LTS + OHDSI HADES 2026Q1
 #
-# A pared-down build of the HADES 2026Q1 release: same pinned package set as
-# Dockerfile_full (renv.lock), installed as binaries from the public Posit
-# Package Manager mirror rather than the Databricks-hosted one. Runs on a
-# standard R base image instead of the Databricks cluster runtime, and skips
-# the from-source R build and the notebook/Rserve glue Dockerfile_full needs
-# for Databricks parity. Use this image for local HADES analyses; use
-# Dockerfile_full when you need parity with a specific Databricks cluster.
+# TEMPORARY: currently mirrors Dockerfile_full exactly (aside from tag/label)
+# so both variants publish successfully while the environment is pared down
+# incrementally. Dockerfile_latest kept hitting missing runtime .so errors
+# from transitive CRAN dependencies (packages HADES itself doesn't need, but
+# something in the lockfile pulls in) each time a leaner base was tried, so
+# for now it reuses Dockerfile_full's proven dependency list rather than
+# rediscovering it one failed build at a time. See Dockerfile_full for the
+# lightweight rework in progress.
 #
-# Build (from the repository root, since COPY sources are rooted there):
+# Apple Silicon build (from the repository root, since COPY sources are
+# rooted there):
 #
 #   docker buildx build \
 #     --platform linux/amd64 \
 #     -t getwilds/hades:latest \
 #     -f hades/Dockerfile_latest \
+#     --load \
 #     .
+#
+# Prefer an amd64 builder where one is available. Under QEMU every package
+# that is not available as a binary is compiled through emulation, which is
+# what pushes the restore past renv's install deadline.
 #
 # The lockfile pulls 16 packages from github.com/ohdsi. Anonymous GitHub API
 # access is capped at 60 requests/hour; renv needs it to resolve each
 # remote's dependencies, but 16 lookups comfortably fits that limit.
 #
+# Packages come from the Databricks Posit Package Manager mirror (same host
+# DBR uses for cluster installs). DBR 17.3 LTS freezes CRAN at 2025-03-20;
+# this image defaults to 2026-03-23 so the HADES 2026Q1 lockfile can install
+# as binaries instead of compiling.
+#
+#   # Match DBR 17.3 LTS freeze (many HADES pins will build from source):
+#   --build-arg PPM_SNAPSHOT=2025-03-20
+#
+#   # Public Posit fallback if the Databricks host is unreachable:
+#   --build-arg PPM_HOST=https://p3m.dev
+#
 # Build args: PPM_HOST, PPM_DISTRO, PPM_SNAPSHOT, CRAN_REPO,
 #             RENV_INSTALL_JOBS, RENV_INSTALL_TIMEOUT.
 #==============================================================================
 
-FROM rocker/r-ver:4.4.1
+FROM databricksruntime/standard:17.3-LTS
 
 # Adding labels for the GitHub Container Registry
 LABEL org.opencontainers.image.title="hades"
@@ -37,110 +56,212 @@ LABEL org.opencontainers.image.documentation=https://getwilds.org/
 LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
 LABEL org.opencontainers.image.licenses=MIT
 
+USER root
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Set R library paths to avoid host contamination in Apptainer
-ENV R_LIBS_USER=/usr/local/lib/R/site-library
-ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
-
 #------------------------------------------------------------------------------
-# 1. Install runtime dependencies for the HADES package stack
-#
-# Java (rJava/DatabaseConnector), ODBC drivers, BLAS/LAPACK, libxml2/libcurl/
-# libssl for HTTP + XML packages, and libnode-dev (provides the V8 engine
-# libv8-dev is a virtual alias for) for V8/CirceR. No X11/Cairo/font
-# libraries: this image is not built for R graphics devices.
-#
-# The runtime (non-dev) libraries below are needed because CRAN_REPO serves
-# prebuilt PPM binaries, which dynamically link against these .so files
-# directly rather than compiling against the -dev packages above
-# (e.g. keyring.so needs libsecret-1.so.0, Matrix.so needs liblapack.so.3).
+# 1. Install build/runtime dependencies
 #------------------------------------------------------------------------------
 
-RUN apt-get update \
-  && DEFAULT_JDK_VERSION=$(apt-cache policy default-jdk | grep Candidate | awk '{print $2}') \
-  && UNIXODBC_VERSION=$(apt-cache policy unixodbc-dev | grep Candidate | awk '{print $2}') \
-  && LIBCURL_VERSION=$(apt-cache policy libcurl4-openssl-dev | grep Candidate | awk '{print $2}') \
-  && LIBSSL_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
-  && LIBXML2_VERSION=$(apt-cache policy libxml2-dev | grep Candidate | awk '{print $2}') \
-  && LIBGIT2_VERSION=$(apt-cache policy libgit2-dev | grep Candidate | awk '{print $2}') \
-  && LIBNODE_VERSION=$(apt-cache policy libnode-dev | grep Candidate | awk '{print $2}') \
-  && LIBSODIUM_VERSION=$(apt-cache policy libsodium-dev | grep Candidate | awk '{print $2}') \
-  && LIBBLAS_VERSION=$(apt-cache policy libblas3 | grep Candidate | awk '{print $2}') \
-  && LIBLAPACK_VERSION=$(apt-cache policy liblapack3 | grep Candidate | awk '{print $2}') \
-  && LIBOPENBLAS_VERSION=$(apt-cache policy libopenblas0 | grep Candidate | awk '{print $2}') \
-  && LIBGOMP_VERSION=$(apt-cache policy libgomp1 | grep Candidate | awk '{print $2}') \
-  && LIBGFORTRAN_VERSION=$(apt-cache policy libgfortran5 | grep Candidate | awk '{print $2}') \
-  && LIBSQLITE3_VERSION=$(apt-cache policy libsqlite3-0 | grep Candidate | awk '{print $2}') \
-  && LIBSECRET_VERSION=$(apt-cache policy libsecret-1-0 | grep Candidate | awk '{print $2}') \
-  && LIBNLOPT_VERSION=$(apt-cache policy libnlopt0 | grep Candidate | awk '{print $2}') \
-  && apt-get install -y --no-install-recommends \
-  default-jdk="${DEFAULT_JDK_VERSION}" \
-  unixodbc-dev="${UNIXODBC_VERSION}" \
-  libcurl4-openssl-dev="${LIBCURL_VERSION}" \
-  libssl-dev="${LIBSSL_VERSION}" \
-  libxml2-dev="${LIBXML2_VERSION}" \
-  libgit2-dev="${LIBGIT2_VERSION}" \
-  libnode-dev="${LIBNODE_VERSION}" \
-  libsodium-dev="${LIBSODIUM_VERSION}" \
-  libblas3="${LIBBLAS_VERSION}" \
-  liblapack3="${LIBLAPACK_VERSION}" \
-  libopenblas0="${LIBOPENBLAS_VERSION}" \
-  libgomp1="${LIBGOMP_VERSION}" \
-  libgfortran5="${LIBGFORTRAN_VERSION}" \
-  libsqlite3-0="${LIBSQLITE3_VERSION}" \
-  libsecret-1-0="${LIBSECRET_VERSION}" \
-  libnlopt0="${LIBNLOPT_VERSION}" \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        wget \
+        git \
+        build-essential \
+        gcc \
+        g++ \
+        gfortran \
+        make \
+        cmake \
+        perl \
+        xz-utils \
+        bzip2 \
+        pkg-config \
+        unixodbc \
+        unixodbc-dev \
+        odbcinst \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libxml2-dev \
+        libgit2-dev \
+        libicu-dev \
+        libbz2-dev \
+        liblzma-dev \
+        zlib1g-dev \
+        libreadline-dev \
+        libncurses-dev \
+        libncurses5-dev \
+        libncursesw5-dev \
+        libtinfo-dev \
+        libpcre2-dev \
+        libx11-dev \
+        libxt-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libtiff-dev \
+        libcairo2-dev \
+        libfontconfig1-dev \
+        libfreetype6-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        # Runtime BLAS/LAPACK for PPM binaries (e.g. Matrix.so needs liblapack.so.3)
+        libblas3 \
+        liblapack3 \
+        libopenblas0 \
+        libgomp1 \
+        # Common PPM binary runtime deps for HADES stack
+        libgfortran5 \
+        libnode109 \
+        libsqlite3-0 \
+        libsecret-1-0 \
+        libnlopt0 \
+        libgit2-1.7 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN R CMD javareconf
+# Validate ODBC:
+RUN odbcinst -j && \
+    test -f /usr/include/sql.h
+
+# Validate BLAS/LAPACK (required by PPM binaries such as Matrix):
+RUN ldconfig -p | grep -E 'lib(lapack|blas|openblas)\.so' && \
+    test -e /usr/lib/"$(dpkg-architecture -qDEB_HOST_MULTIARCH)"/liblapack.so.3
+
+# Validate full Java JDK:
+RUN java -version && \
+    javac -version
 
 #------------------------------------------------------------------------------
-# 2. Configure R package defaults
+# 2. Configure CRAN repository for Ubuntu 24.04
+#------------------------------------------------------------------------------
+
+RUN mkdir -p /etc/apt/keyrings && \
+    gpg --keyserver hkp://keyserver.ubuntu.com:80 \
+        --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+    gpg --export E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+        > /etc/apt/keyrings/cran.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/cran.gpg] https://cloud.r-project.org/bin/linux/ubuntu noble-cran40/" \
+        > /etc/apt/sources.list.d/cran-r.list
+
+#------------------------------------------------------------------------------
+# 3. Install R 4.4.1
 #
-# CRAN_REPO points at the public Posit Package Manager binary URL for Ubuntu
-# jammy (this image's base OS) so the restore installs prebuilt binaries
-# instead of compiling ~278 CRAN packages from source, the way plain
-# cloud.r-project.org would on Linux.
+# Match OHDSI HADES recommended R version.
+#------------------------------------------------------------------------------
+
+ARG R_VERSION=4.4.1
+
+WORKDIR /tmp
+
+RUN curl -fsSL \
+    https://cran.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz \
+    -o R-${R_VERSION}.tar.gz && \
+    tar -xzf R-${R_VERSION}.tar.gz && \
+    cd R-${R_VERSION} && \
+    ./configure \
+        --prefix=/usr/local \
+        --enable-R-shlib \
+        --with-x \
+        --with-blas \
+        --with-lapack && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd / && \
+    rm -rf \
+        /tmp/R-${R_VERSION} \
+        /tmp/R-${R_VERSION}.tar.gz
+
+#------------------------------------------------------------------------------
+# 4. Validate R and Java
+#------------------------------------------------------------------------------
+
+RUN echo "===== R VERSION =====" && \
+    R --version && \
+    R -e 'stopifnot(getRversion() == "4.4.1")'
+
+RUN echo "===== JAVA VERSION =====" && \
+    java -version
+
+#------------------------------------------------------------------------------
+# 5. Configure R <-> Java
+#------------------------------------------------------------------------------
+
+RUN _JAVA_OPTIONS="-Xmx4g" R CMD javareconf
+
+#------------------------------------------------------------------------------
+# 6. Configure R package defaults
+#
+# CRAN_REPO points at Databricks' Posit Package Manager binary URL for
+# Ubuntu noble. Pins missing from that snapshot fall through to
+# cloud.r-project.org (see RENV_CONFIG_REPOS_OVERRIDE below).
 #
 # RENV_INSTALL_TIMEOUT is the deadline renv applies to the *entire* install
 # phase, not to individual packages. renv defaults to 3600 seconds, which
-# this lockfile can overrun even with binaries available.
+# this lockfile overruns under QEMU/source builds.
 #------------------------------------------------------------------------------
 
-ARG PPM_HOST=https://packagemanager.posit.co
-ARG PPM_DISTRO=jammy
-ARG PPM_SNAPSHOT=latest
+ARG PPM_HOST=https://databricks.packagemanager.posit.co
+ARG PPM_DISTRO=noble
+# DBR 17.3 LTS freezes at 2025-03-20. Default is later so HADES 2026Q1
+# pins install as binaries from the same Databricks PPM host.
+ARG PPM_SNAPSHOT=2026-03-23
 ARG CRAN_REPO=${PPM_HOST}/cran/__linux__/${PPM_DISTRO}/${PPM_SNAPSHOT}
 ARG RENV_INSTALL_JOBS=4
 ARG RENV_INSTALL_TIMEOUT=21600
 
-ENV RENV_INSTALL_TIMEOUT=${RENV_INSTALL_TIMEOUT}
+ENV CRAN_REPO=${CRAN_REPO} \
+    RENV_INSTALL_TIMEOUT=${RENV_INSTALL_TIMEOUT}
+
+COPY hades/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 #------------------------------------------------------------------------------
-# 3. Install renv
+# 7. Install renv
 #------------------------------------------------------------------------------
 
-RUN R -e "install.packages(c('renv', 'jsonlite'), repos = '${CRAN_REPO}')" && \
+RUN R -e "install.packages(c('renv', 'jsonlite'))" && \
     R -e "stopifnot( \
         requireNamespace('renv', quietly = TRUE), \
         requireNamespace('jsonlite', quietly = TRUE) \
     )"
 
 #------------------------------------------------------------------------------
-# 4. Restore the pinned HADES 2026Q1 lockfile
-#
-# Same two-pass strategy as Dockerfile_full: CRAN packages first, so the
-# ohdsi/* GitHub remotes have their dependencies present regardless of what
-# renv managed to resolve over the GitHub API.
+# 8. Create HADES environment
 #------------------------------------------------------------------------------
 
 WORKDIR /opt/ohdsi/hades
 
+#------------------------------------------------------------------------------
+# 9. Copy the pinned HADES-wide release lockfile
+#------------------------------------------------------------------------------
+
 COPY hades/renv.lock /opt/ohdsi/hades/renv.lock
+
+#------------------------------------------------------------------------------
+# 10. Verify the lockfile and R version
+#------------------------------------------------------------------------------
+
+RUN R -e " \
+    lock <- jsonlite::read_json('/opt/ohdsi/hades/renv.lock'); \
+    cat('HADES lockfile R version:', lock\$R\$Version, '\n'); \
+    cat('Container R version:', as.character(getRversion()), '\n'); \
+    stopifnot(lock\$R\$Version == '4.4.1'); \
+    stopifnot(as.character(getRversion()) == '4.4.1') \
+    "
+
+#------------------------------------------------------------------------------
+# 11. Restore HADES-wide dependency snapshot
+#
+# renv's cache and downloaded sources live in a build cache mount so a retry
+# does not start from an empty cache. Cache symlinks are off so restored
+# packages are copied into the library and the image does not depend on that
+# mount existing.
+#------------------------------------------------------------------------------
+
 COPY hades/install-hades.R /opt/ohdsi/hades/install-hades.R
 
 RUN --mount=type=cache,target=/opt/renv,sharing=locked \
@@ -151,11 +272,40 @@ RUN --mount=type=cache,target=/opt/renv,sharing=locked \
     Rscript /opt/ohdsi/hades/install-hades.R
 
 #------------------------------------------------------------------------------
-# 5. Validate the HADES environment (smoke test)
+# 12. Reconfigure Java after package restore
+#------------------------------------------------------------------------------
+
+RUN R CMD javareconf
+
+# Packages Databricks requires to start an R REPL in notebooks.
+# Rserve backs the driver's R connection; hwriterPlus renders cell output.
+RUN R -e "install.packages(c('hwriter', 'TeachingDemos'))" && \
+    R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/hwriterPlus/hwriterPlus_1.0-3.tar.gz', repos = NULL, type = 'source')" && \
+    R -e "install.packages('Rserve', repos = 'http://rforge.net/')" && \
+    R -e "stopifnot(nzchar(system.file(package = 'Rserve')), nzchar(system.file(package = 'hwriterPlus')))"
+
+#------------------------------------------------------------------------------
+# 13. Copy validation script
 #------------------------------------------------------------------------------
 
 COPY hades/validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
 
-RUN Rscript /opt/ohdsi/hades/validate-ohdsi.R
+#------------------------------------------------------------------------------
+# 14. Validate the OHDSI/HADES environment (smoke test)
+#------------------------------------------------------------------------------
 
-WORKDIR /data
+RUN _JAVA_OPTIONS="-Xmx4g" Rscript /opt/ohdsi/hades/validate-ohdsi.R
+
+#------------------------------------------------------------------------------
+# 15. Final environment info
+#------------------------------------------------------------------------------
+
+RUN echo "===================================" && \
+    echo "Final OHDSI / Databricks environment" && \
+    echo "===================================" && \
+    R --version && \
+    java -version
+
+WORKDIR /
+
+RUN echo 'options(bitmapType = "cairo")' >> /usr/local/lib/R/etc/Rprofile.site

--- a/hades/Dockerfile_latest
+++ b/hades/Dockerfile_latest
@@ -1,0 +1,127 @@
+#==============================================================================
+# OHDSI HADES 2026Q1 (lightweight)
+#
+# A pared-down build of the HADES 2026Q1 release: same pinned package set as
+# Dockerfile_full (renv.lock), but on a standard R base image instead of the
+# Databricks cluster runtime, and without the from-source R build, the
+# Databricks Posit Package Manager mirror, or the notebook/Rserve glue those
+# require. Use this image for local HADES analyses; use Dockerfile_full when
+# you need parity with a specific Databricks cluster.
+#
+# Build:
+#
+#   docker buildx build \
+#     --platform linux/amd64 \
+#     -t getwilds/hades:latest \
+#     .
+#
+# The lockfile pulls 16 packages from github.com/ohdsi. Anonymous GitHub API
+# access is capped at 60 requests/hour; renv needs it to resolve each
+# remote's dependencies, but 16 lookups comfortably fits that limit.
+#==============================================================================
+
+FROM rocker/r-ver:4.4.1
+
+# Adding labels for the GitHub Container Registry
+LABEL org.opencontainers.image.title="hades"
+LABEL org.opencontainers.image.description="Docker image for OHDSI HADES 2026Q1 in Fred Hutch OCDO's WILDS"
+LABEL org.opencontainers.image.version="latest"
+LABEL org.opencontainers.image.authors="wilds@fredhutch.org"
+LABEL org.opencontainers.image.url=https://ocdo.fredhutch.org/
+LABEL org.opencontainers.image.documentation=https://getwilds.org/
+LABEL org.opencontainers.image.source=https://github.com/getwilds/wilds-docker-library
+LABEL org.opencontainers.image.licenses=MIT
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Set R library paths to avoid host contamination in Apptainer
+ENV R_LIBS_USER=/usr/local/lib/R/site-library
+ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
+
+#------------------------------------------------------------------------------
+# 1. Install runtime dependencies for the HADES package stack
+#
+# Java (rJava/DatabaseConnector), ODBC drivers, BLAS/LAPACK, libxml2/libcurl/
+# libssl for HTTP + XML packages, and libnode-dev (provides the V8 engine
+# libv8-dev is a virtual alias for) for V8/CirceR. No X11/Cairo/font
+# libraries: this image is not built for R graphics devices.
+#------------------------------------------------------------------------------
+
+RUN apt-get update \
+  && DEFAULT_JDK_VERSION=$(apt-cache policy default-jdk | grep Candidate | awk '{print $2}') \
+  && UNIXODBC_VERSION=$(apt-cache policy unixodbc-dev | grep Candidate | awk '{print $2}') \
+  && LIBCURL_VERSION=$(apt-cache policy libcurl4-openssl-dev | grep Candidate | awk '{print $2}') \
+  && LIBSSL_VERSION=$(apt-cache policy libssl-dev | grep Candidate | awk '{print $2}') \
+  && LIBXML2_VERSION=$(apt-cache policy libxml2-dev | grep Candidate | awk '{print $2}') \
+  && LIBGIT2_VERSION=$(apt-cache policy libgit2-dev | grep Candidate | awk '{print $2}') \
+  && LIBNODE_VERSION=$(apt-cache policy libnode-dev | grep Candidate | awk '{print $2}') \
+  && LIBSODIUM_VERSION=$(apt-cache policy libsodium-dev | grep Candidate | awk '{print $2}') \
+  && apt-get install -y --no-install-recommends \
+  default-jdk="${DEFAULT_JDK_VERSION}" \
+  unixodbc-dev="${UNIXODBC_VERSION}" \
+  libcurl4-openssl-dev="${LIBCURL_VERSION}" \
+  libssl-dev="${LIBSSL_VERSION}" \
+  libxml2-dev="${LIBXML2_VERSION}" \
+  libgit2-dev="${LIBGIT2_VERSION}" \
+  libnode-dev="${LIBNODE_VERSION}" \
+  libsodium-dev="${LIBSODIUM_VERSION}" \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN R CMD javareconf
+
+#------------------------------------------------------------------------------
+# 2. Configure R package defaults
+#
+# RENV_INSTALL_TIMEOUT is the deadline renv applies to the *entire* install
+# phase, not to individual packages. renv defaults to 3600 seconds, which
+# this lockfile overruns once anything compiles from source.
+#------------------------------------------------------------------------------
+
+ARG CRAN_REPO=https://cloud.r-project.org
+ARG RENV_INSTALL_JOBS=4
+ARG RENV_INSTALL_TIMEOUT=21600
+
+ENV RENV_INSTALL_TIMEOUT=${RENV_INSTALL_TIMEOUT}
+
+#------------------------------------------------------------------------------
+# 3. Install renv
+#------------------------------------------------------------------------------
+
+RUN R -e "install.packages(c('renv', 'jsonlite'), repos = '${CRAN_REPO}')" && \
+    R -e "stopifnot( \
+        requireNamespace('renv', quietly = TRUE), \
+        requireNamespace('jsonlite', quietly = TRUE) \
+    )"
+
+#------------------------------------------------------------------------------
+# 4. Restore the pinned HADES 2026Q1 lockfile
+#
+# Same two-pass strategy as Dockerfile_full: CRAN packages first, so the
+# ohdsi/* GitHub remotes have their dependencies present regardless of what
+# renv managed to resolve over the GitHub API.
+#------------------------------------------------------------------------------
+
+WORKDIR /opt/ohdsi/hades
+
+COPY renv.lock /opt/ohdsi/hades/renv.lock
+COPY install-hades.R /opt/ohdsi/hades/install-hades.R
+
+RUN --mount=type=cache,target=/opt/renv,sharing=locked \
+    RENV_PATHS_ROOT=/opt/renv \
+    RENV_CONFIG_CACHE_SYMLINKS=FALSE \
+    RENV_CONFIG_REPOS_OVERRIDE="CRAN=${CRAN_REPO}" \
+    RENV_CONFIG_INSTALL_JOBS="${RENV_INSTALL_JOBS}" \
+    Rscript /opt/ohdsi/hades/install-hades.R
+
+#------------------------------------------------------------------------------
+# 5. Validate the HADES environment (smoke test)
+#------------------------------------------------------------------------------
+
+COPY validate-ohdsi.R /opt/ohdsi/hades/validate-ohdsi.R
+
+RUN Rscript /opt/ohdsi/hades/validate-ohdsi.R
+
+WORKDIR /data

--- a/hades/README.md
+++ b/hades/README.md
@@ -18,15 +18,19 @@ Two variants are provided, both built from the same pinned HADES 2026Q1 lockfile
 
 ## Building
 
+Run from the repository root, since each Dockerfile's `COPY` sources (`renv.lock`, `install-hades.R`, `validate-ohdsi.R`, `Rprofile.site`) are rooted there, matching how `docker_update.py` builds and publishes these images in CI:
+
 ```bash
 # Lightweight build
 docker buildx build --platform linux/amd64 -t getwilds/hades:latest \
-  hades/ -f hades/Dockerfile_latest
+  -f hades/Dockerfile_latest .
 
 # Databricks-parity build
 docker buildx build --platform linux/amd64 -t getwilds/hades:full \
-  hades/ -f hades/Dockerfile_full
+  -f hades/Dockerfile_full .
 ```
+
+**Note:** `make build_amd64 IMAGE=hades` (and `make build`/`make validate`) will *not* work for this tool, since the Makefile builds every tool with that tool's own subdirectory as context (`docker build ... hades/`), while these Dockerfiles expect repo-root context to resolve their `COPY` paths. Use the `docker buildx build` commands above for local builds instead.
 
 ## Usage
 

--- a/hades/README.md
+++ b/hades/README.md
@@ -1,0 +1,91 @@
+# HADES
+
+This directory contains Docker images for [HADES](https://ohdsi.github.io/Hades/) (Health Analytics Data-to-Evidence Suite), the OHDSI collection of R packages for large-scale observational health data analysis on the OMOP Common Data Model.
+
+Two variants are provided, both built from the same pinned HADES 2026Q1 lockfile (`renv.lock`, 294 packages including 16 pulled from `github.com/ohdsi`):
+
+- **`latest`**: A lightweight build on a standard R base image, without Databricks-specific components. Recommended for local development and general HADES analyses.
+- **`full`**: A full-parity build on the same Databricks Runtime 17.3 LTS and Posit Package Manager mirror used in production Databricks clusters. Use this variant when you need the container's environment to match a specific Databricks cluster.
+
+## Available Versions
+
+- `latest`: Lightweight HADES 2026Q1 build (R 4.4.1, `rocker/r-ver` base)
+- `full`: Databricks-parity HADES 2026Q1 build (R 4.4.1, `databricksruntime/standard:17.3-LTS` base)
+
+## Platform Availability
+
+**Note:** These images are built for **linux/amd64** only. Several HADES dependencies (e.g. `duckdb`, `Cyclops`) are compiled from source during the `renv` restore, and the R 4.4.1 build in the `full` variant is not validated under QEMU emulation.
+
+## Building
+
+```bash
+# Lightweight build
+docker buildx build --platform linux/amd64 -t getwilds/hades:latest \
+  hades/ -f hades/Dockerfile_latest
+
+# Databricks-parity build
+docker buildx build --platform linux/amd64 -t getwilds/hades:full \
+  hades/ -f hades/Dockerfile_full
+```
+
+## Usage
+
+### Docker
+
+```bash
+docker pull getwilds/hades:latest
+# or
+docker pull getwilds/hades:full
+
+# Alternatively, pull from GitHub Container Registry
+docker pull ghcr.io/getwilds/hades:latest
+```
+
+### Singularity/Apptainer
+
+```bash
+apptainer pull docker://getwilds/hades:latest
+
+# Alternatively, pull from GitHub Container Registry
+apptainer pull docker://ghcr.io/getwilds/hades:latest
+```
+
+### Example Commands
+
+```bash
+# Launch an interactive R session with HADES loaded
+docker run --rm -it -v /path/to/data:/data getwilds/hades:latest R
+
+# Run an R script that uses HADES packages
+docker run --rm -v /path/to/data:/data getwilds/hades:latest Rscript /data/my_analysis.R
+
+# Alternatively using Apptainer
+apptainer run --bind /path/to/data:/data docker://getwilds/hades:latest R
+```
+
+## Installed Components
+
+Both images restore the full HADES 2026Q1 lockfile, including:
+
+- **Foundations**: DatabaseConnector, SqlRender, ParallelLogger, Andromeda, Cyclops, duckdb, V8, CirceR, Eunomia
+- **Analytics**: Achilles, DataQualityDashboard, CohortGenerator, CohortDiagnostics, FeatureExtraction, PatientLevelPrediction, CohortMethod, SelfControlledCaseSeries, Characterization, ResultModelManager
+- **GitHub-only OHDSI packages**: Capr, Strategus, Hades, CohortExplorer, CohortIncidence, DeepPatientLevelPrediction, EnsemblePatientLevelPrediction, Keeper, MethodEvaluation, OhdsiSharing, OhdsiShinyModules, PhenotypeLibrary, PheValuator, ROhdsiWebApi, SelfControlledCohort
+
+The `full` variant additionally includes Databricks notebook integration (Rserve, hwriterPlus) and compiles R 4.4.1 from source to match the Databricks Runtime environment exactly.
+
+## Security Features
+
+- Pinned R version (4.4.1) and pinned package versions via `renv.lock` for reproducibility
+- Dynamic versioning for system dependencies (`latest` variant) to ensure the latest security patches
+
+### Security Scanning and CVEs
+
+These images are regularly scanned for vulnerabilities using Docker Scout. However, due to the size and nature of the HADES dependency tree, some images may contain components with known vulnerabilities (CVEs).
+
+**Use at your own risk**: While we strive to minimize security issues, these images are primarily designed for research and analytical workflows in controlled environments.
+
+For the latest security information about these images, please check the `CVEs_*.md` files in this directory, which are automatically updated through our GitHub Actions workflow. Critical or high-severity vulnerabilities will also be reported as GitHub issues in the repository.
+
+## Source Repository
+
+These Dockerfiles are maintained in the [WILDS Docker Library](https://github.com/getwilds/wilds-docker-library) repository. See [CONTRIBUTING.md](https://github.com/getwilds/wilds-docker-library/blob/main/CONTRIBUTING.md) for details on contributing new images or updates.

--- a/hades/README.md
+++ b/hades/README.md
@@ -2,14 +2,14 @@
 
 This directory contains Docker images for [HADES](https://ohdsi.github.io/Hades/) (Health Analytics Data-to-Evidence Suite), the OHDSI collection of R packages for large-scale observational health data analysis on the OMOP Common Data Model.
 
-Two variants are provided, both built from the same pinned HADES 2026Q1 lockfile (`renv.lock`, 294 packages including 16 pulled from `github.com/ohdsi`):
+Two tags are provided, both built from the same pinned HADES 2026Q1 lockfile (`renv.lock`, 294 packages including 16 pulled from `github.com/ohdsi`):
 
-- **`latest`**: A lightweight build on a standard R base image, without Databricks-specific components. Recommended for local development and general HADES analyses.
 - **`full`**: A full-parity build on the same Databricks Runtime 17.3 LTS and Posit Package Manager mirror used in production Databricks clusters. Use this variant when you need the container's environment to match a specific Databricks cluster.
+- **`latest`**: Currently identical to `full`. A lighter, non-Databricks-specific build is planned (see [Known Limitations](#known-limitations)), but every leaner base tried so far has hit missing runtime libraries pulled in by transitive CRAN dependencies, so `latest` temporarily mirrors `full` to keep both tags publishing successfully.
 
 ## Available Versions
 
-- `latest`: Lightweight HADES 2026Q1 build (R 4.4.1, `rocker/r-ver` base)
+- `latest`: HADES 2026Q1 build (R 4.4.1, `databricksruntime/standard:17.3-LTS` base) — currently identical to `full`
 - `full`: Databricks-parity HADES 2026Q1 build (R 4.4.1, `databricksruntime/standard:17.3-LTS` base)
 
 ## Platform Availability
@@ -21,16 +21,14 @@ Two variants are provided, both built from the same pinned HADES 2026Q1 lockfile
 Run from the repository root, since each Dockerfile's `COPY` sources (`renv.lock`, `install-hades.R`, `validate-ohdsi.R`, `Rprofile.site`) are rooted there, matching how `docker_update.py` builds and publishes these images in CI:
 
 ```bash
-# Lightweight build
 docker buildx build --platform linux/amd64 -t getwilds/hades:latest \
   -f hades/Dockerfile_latest .
 
-# Databricks-parity build
 docker buildx build --platform linux/amd64 -t getwilds/hades:full \
   -f hades/Dockerfile_full .
 ```
 
-**Note:** `make build_amd64 IMAGE=hades` (and `make build`/`make validate`) will *not* work for this tool, since the Makefile builds every tool with that tool's own subdirectory as context (`docker build ... hades/`), while these Dockerfiles expect repo-root context to resolve their `COPY` paths. Use the `docker buildx build` commands above for local builds instead.
+See [Known Limitations](#known-limitations) below for a note on `make build_amd64`.
 
 ## Usage
 
@@ -69,18 +67,23 @@ apptainer run --bind /path/to/data:/data docker://getwilds/hades:latest R
 
 ## Installed Components
 
-Both images restore the full HADES 2026Q1 lockfile, including:
+Both tags restore the full HADES 2026Q1 lockfile, including:
 
 - **Foundations**: DatabaseConnector, SqlRender, ParallelLogger, Andromeda, Cyclops, duckdb, V8, CirceR, Eunomia
 - **Analytics**: Achilles, DataQualityDashboard, CohortGenerator, CohortDiagnostics, FeatureExtraction, PatientLevelPrediction, CohortMethod, SelfControlledCaseSeries, Characterization, ResultModelManager
 - **GitHub-only OHDSI packages**: Capr, Strategus, Hades, CohortExplorer, CohortIncidence, DeepPatientLevelPrediction, EnsemblePatientLevelPrediction, Keeper, MethodEvaluation, OhdsiSharing, OhdsiShinyModules, PhenotypeLibrary, PheValuator, ROhdsiWebApi, SelfControlledCohort
 
-The `full` variant additionally includes Databricks notebook integration (Rserve, hwriterPlus) and compiles R 4.4.1 from source to match the Databricks Runtime environment exactly.
+Both tags currently also include Databricks notebook integration (Rserve, hwriterPlus) and compile R 4.4.1 from source to match the Databricks Runtime environment exactly, since `latest` mirrors `full` for now (see [Known Limitations](#known-limitations)).
+
+## Known Limitations
+
+- **`latest` does not yet have a lightweight build.** It is currently identical to `full`, including the Databricks base image, from-source R compile, and notebook glue that a "lightweight" tag should not need. Earlier attempts at a leaner `rocker/r-ver`-based build repeatedly failed on missing runtime `.so` libraries (e.g. `libsecret-1.so.0` for `keyring`, `libwebpmux.so.3` for `ragg`) pulled in by transitive CRAN dependencies in the lockfile, not by HADES itself. Pare this back incrementally with the working `full` dependency list as a reference, verifying each trimmed-down build against the full `renv.lock` restore before removing more.
+- **`make build_amd64 IMAGE=hades`** (and `make build`/`make validate`) will not work for this tool: the Makefile builds every tool with that tool's own subdirectory as context (`docker build ... hades/`), while these Dockerfiles expect repo-root context to resolve their `COPY` paths. Use the `docker buildx build` commands in [Building](#building) instead.
 
 ## Security Features
 
 - Pinned R version (4.4.1) and pinned package versions via `renv.lock` for reproducibility
-- Dynamic versioning for system dependencies (`latest` variant) to ensure the latest security patches
+- Pinned versions for system dependencies via `apt-cache policy` to ensure reproducible, security-patched builds
 
 ### Security Scanning and CVEs
 

--- a/hades/Rprofile.site
+++ b/hades/Rprofile.site
@@ -1,0 +1,39 @@
+# Site-wide R defaults for the OHDSI/HADES image.
+#
+# Installed as /usr/local/lib/R/etc/Rprofile.site so the build steps, the
+# validation script, and any R session started on the cluster all agree on
+# where packages come from and how long renv may spend installing them.
+
+local({
+
+  # CRAN_REPO is set as an image environment variable. Default is the
+  # Databricks Posit Package Manager binary URL for Ubuntu noble -- the
+  # same mirror DBR uses for cluster package installs. Posit serves Linux
+  # binaries only when the User-Agent reports an R version.
+  repo <- Sys.getenv(
+    "CRAN_REPO",
+    unset = "https://databricks.packagemanager.posit.co/cran/__linux__/noble/2026-03-23"
+  )
+
+  options(
+    repos = c(CRAN = repo),
+    HTTPUserAgent = sprintf(
+      "R/%s R (%s)",
+      getRversion(),
+      paste(
+        getRversion(),
+        R.version$platform,
+        R.version$arch,
+        R.version$os
+      )
+    )
+  )
+
+  # renv's default 3600 second deadline covers the whole install phase, which
+  # is not enough for a lockfile this size once anything compiles from source.
+  timeout <- suppressWarnings(as.integer(Sys.getenv("RENV_INSTALL_TIMEOUT")))
+  if (!is.na(timeout) && timeout > 0L) {
+    options(renv.install.timeout = timeout)
+  }
+
+})

--- a/hades/install-hades.R
+++ b/hades/install-hades.R
@@ -1,0 +1,156 @@
+#!/usr/bin/env Rscript
+
+# Restores the pinned HADES lockfile into the R library.
+#
+# Three things about this lockfile need handling explicitly:
+#
+# 1. renv applies one deadline to the whole install phase
+#    (options(renv.install.timeout), 3600 seconds by default). Nearly 300
+#    packages overrun it whenever they are compiled rather than downloaded as
+#    binaries, and whatever is still building when the deadline passes is
+#    killed with "worker process timed out".
+#
+# 2. A transactional restore keeps installed packages in a staging library and
+#    only migrates them once every package has succeeded, so a single failure
+#    throws away the entire run. Installing non-transactionally means progress
+#    survives, which is what makes the two passes below worthwhile.
+#
+# 3. renv learns a GitHub remote's dependencies by fetching its DESCRIPTION
+#    over the network. When that lookup fails, the remote looks dependency-free
+#    and gets scheduled in the first install wave, so R CMD INSTALL aborts with
+#    "dependencies ... are not available". The first pass installs everything
+#    from CRAN, so by the time the ohdsi/* remotes are built their dependencies
+#    are present regardless of what renv managed to resolve.
+
+lockfile <- Sys.getenv("HADES_LOCKFILE", unset = "/opt/ohdsi/hades/renv.lock")
+
+timeout <- suppressWarnings(as.integer(Sys.getenv("RENV_INSTALL_TIMEOUT")))
+if (!is.na(timeout) && timeout > 0L) {
+  options(renv.install.timeout = timeout)
+}
+
+records <- jsonlite::read_json(lockfile)$Packages
+if (!length(records)) {
+  stop("no package records found in ", lockfile)
+}
+
+from_cran <- vapply(
+  records,
+  function(record) identical(record$Source, "Repository"),
+  logical(1)
+)
+
+cran <- names(records)[from_cran]
+remotes <- names(records)[!from_cran]
+
+
+# ------------------------------------------------------------
+# Report the settings that decide how long this takes
+# ------------------------------------------------------------
+
+cat("Lockfile:        ", lockfile, "\n", sep = "")
+cat("Library:         ", .libPaths()[1], "\n", sep = "")
+cat("Repositories:    ", paste(getOption("repos"), collapse = ", "), "\n", sep = "")
+cat("Install jobs:    ", Sys.getenv("RENV_CONFIG_INSTALL_JOBS", "renv default"), "\n", sep = "")
+cat("Install deadline:", getOption("renv.install.timeout", "renv default"), "seconds\n")
+cat("GitHub token:    ", if (nzchar(Sys.getenv("GITHUB_PAT"))) "set" else "absent (60 API requests/hour)", "\n", sep = "")
+cat("Packages:        ", length(cran), "from CRAN,", length(remotes), "from remotes\n")
+
+
+# ------------------------------------------------------------
+# Pass 1: CRAN packages
+#
+# Failures are tolerated here; anything left over is the second
+# pass's problem. Only the second pass decides the exit status.
+# ------------------------------------------------------------
+
+if (length(cran)) {
+
+  cat("\n===== pass 1: CRAN packages =====\n")
+
+  attempt <- try(
+    renv::restore(
+      lockfile      = lockfile,
+      packages      = cran,
+      transactional = FALSE,
+      prompt        = FALSE
+    )
+  )
+
+  if (inherits(attempt, "try-error")) {
+    cat("\nPass 1 left packages unresolved; continuing to pass 2.\n")
+  }
+
+}
+
+
+# ------------------------------------------------------------
+# Pass 2: the full lockfile, including the ohdsi/* remotes
+# ------------------------------------------------------------
+
+cat("\n===== pass 2: full lockfile =====\n")
+
+renv::restore(
+  lockfile      = lockfile,
+  transactional = FALSE,
+  prompt        = FALSE
+)
+
+
+# ------------------------------------------------------------
+# Verify every record in the lockfile is installed
+#
+# renv::restore() reports its own failures, but a package can also go
+# missing because a dependency was dropped or an install was rolled
+# back, so check the library itself rather than trusting the summary.
+# ------------------------------------------------------------
+
+cat("\n===== verifying installed library =====\n")
+
+installed <- vapply(
+  names(records),
+  function(package) nzchar(system.file(package = package)),
+  logical(1)
+)
+
+missing <- names(records)[!installed]
+
+if (length(missing)) {
+  stop(
+    sprintf(
+      "%d of %d lockfile packages are not installed: %s",
+      length(missing),
+      length(records),
+      paste(missing, collapse = ", ")
+    )
+  )
+}
+
+# Lockfile versions are occasionally recorded with a leading "v" (a git tag
+# rather than a package version), which never matches DESCRIPTION.
+pinned <- function(package) sub("^v", "", records[[package]]$Version)
+
+drifted <- Filter(
+  function(package) {
+    !identical(as.character(packageVersion(package)), pinned(package))
+  },
+  names(records)
+)
+
+if (length(drifted)) {
+  cat(sprintf("%d package(s) differ from the pinned version:\n", length(drifted)))
+  for (package in drifted) {
+    cat(sprintf(
+      "  %-32s lockfile %-14s installed %s\n",
+      package,
+      pinned(package),
+      as.character(packageVersion(package))
+    ))
+  }
+}
+
+cat(sprintf(
+  "\nAll %d lockfile packages are installed in %s\n",
+  length(records),
+  .libPaths()[1]
+))

--- a/hades/renv.lock
+++ b/hades/renv.lock
@@ -1,0 +1,1841 @@
+{
+	"R" : {
+		"Version" : "4.4.1",
+		"Repositories" : [
+			{
+				"Name" : "CRAN",
+				"URL" : "https://cloud.r-project.org"
+			}
+		]
+	},
+	"Packages" : {
+		"cli" : {
+			"Package" : "cli",
+			"Version" : "3.6.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rlang" : {
+			"Package" : "rlang",
+			"Version" : "1.1.7",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"glue" : {
+			"Package" : "glue",
+			"Version" : "1.8.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lifecycle" : {
+			"Package" : "lifecycle",
+			"Version" : "1.0.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"utf8" : {
+			"Package" : "utf8",
+			"Version" : "1.2.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"vctrs" : {
+			"Package" : "vctrs",
+			"Version" : "0.7.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"magrittr" : {
+			"Package" : "magrittr",
+			"Version" : "2.0.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pillar" : {
+			"Package" : "pillar",
+			"Version" : "1.11.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pkgconfig" : {
+			"Package" : "pkgconfig",
+			"Version" : "2.0.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"withr" : {
+			"Package" : "withr",
+			"Version" : "3.0.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"generics" : {
+			"Package" : "generics",
+			"Version" : "0.1.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"R6" : {
+			"Package" : "R6",
+			"Version" : "2.6.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"stringi" : {
+			"Package" : "stringi",
+			"Version" : "1.8.7",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tibble" : {
+			"Package" : "tibble",
+			"Version" : "3.3.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tidyselect" : {
+			"Package" : "tidyselect",
+			"Version" : "1.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"cpp11" : {
+			"Package" : "cpp11",
+			"Version" : "0.5.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"dplyr" : {
+			"Package" : "dplyr",
+			"Version" : "1.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"farver" : {
+			"Package" : "farver",
+			"Version" : "2.1.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"labeling" : {
+			"Package" : "labeling",
+			"Version" : "0.4.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lattice" : {
+			"Package" : "lattice",
+			"Version" : "0.22-9",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"purrr" : {
+			"Package" : "purrr",
+			"Version" : "1.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"RColorBrewer" : {
+			"Package" : "RColorBrewer",
+			"Version" : "1.1-3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"stringr" : {
+			"Package" : "stringr",
+			"Version" : "1.6.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"viridisLite" : {
+			"Package" : "viridisLite",
+			"Version" : "0.4.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"backports" : {
+			"Package" : "backports",
+			"Version" : "1.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"base64enc" : {
+			"Package" : "base64enc",
+			"Version" : "0.1-6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"digest" : {
+			"Package" : "digest",
+			"Version" : "0.6.39",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"fastmap" : {
+			"Package" : "fastmap",
+			"Version" : "1.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gtable" : {
+			"Package" : "gtable",
+			"Version" : "0.3.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"isoband" : {
+			"Package" : "isoband",
+			"Version" : "0.3.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"nlme" : {
+			"Package" : "nlme",
+			"Version" : "3.1-168",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rbibutils" : {
+			"Package" : "rbibutils",
+			"Version" : "2.4.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Rcpp" : {
+			"Package" : "Rcpp",
+			"Version" : "1.1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"S7" : {
+			"Package" : "S7",
+			"Version" : "0.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"scales" : {
+			"Package" : "scales",
+			"Version" : "1.4.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tidyr" : {
+			"Package" : "tidyr",
+			"Version" : "1.3.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"zoo" : {
+			"Package" : "zoo",
+			"Version" : "1.8-15",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"broom" : {
+			"Package" : "broom",
+			"Version" : "1.0.12",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"cachem" : {
+			"Package" : "cachem",
+			"Version" : "1.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"colorspace" : {
+			"Package" : "colorspace",
+			"Version" : "2.1-2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"fracdiff" : {
+			"Package" : "fracdiff",
+			"Version" : "1.5-3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"fs" : {
+			"Package" : "fs",
+			"Version" : "2.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggplot2" : {
+			"Package" : "ggplot2",
+			"Version" : "4.0.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"htmltools" : {
+			"Package" : "htmltools",
+			"Version" : "0.5.9",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lmtest" : {
+			"Package" : "lmtest",
+			"Version" : "0.9-40",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Matrix" : {
+			"Package" : "Matrix",
+			"Version" : "1.7-4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"nnet" : {
+			"Package" : "nnet",
+			"Version" : "7.3-20",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rappdirs" : {
+			"Package" : "rappdirs",
+			"Version" : "0.3.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"RcppArmadillo" : {
+			"Package" : "RcppArmadillo",
+			"Version" : "15.2.4-1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Rdpack" : {
+			"Package" : "Rdpack",
+			"Version" : "2.6.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"timeDate" : {
+			"Package" : "timeDate",
+			"Version" : "4052.112",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"urca" : {
+			"Package" : "urca",
+			"Version" : "1.3-4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"xfun" : {
+			"Package" : "xfun",
+			"Version" : "0.57",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"bit" : {
+			"Package" : "bit",
+			"Version" : "4.6.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"boot" : {
+			"Package" : "boot",
+			"Version" : "1.3-32",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"cowplot" : {
+			"Package" : "cowplot",
+			"Version" : "1.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"crayon" : {
+			"Package" : "crayon",
+			"Version" : "1.5.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Deriv" : {
+			"Package" : "Deriv",
+			"Version" : "4.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"evaluate" : {
+			"Package" : "evaluate",
+			"Version" : "1.0.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"forecast" : {
+			"Package" : "forecast",
+			"Version" : "9.0.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"highr" : {
+			"Package" : "highr",
+			"Version" : "0.12",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"hms" : {
+			"Package" : "hms",
+			"Version" : "1.1.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"jquerylib" : {
+			"Package" : "jquerylib",
+			"Version" : "0.1.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"jsonlite" : {
+			"Package" : "jsonlite",
+			"Version" : "2.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"MASS" : {
+			"Package" : "MASS",
+			"Version" : "7.3-65",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"memoise" : {
+			"Package" : "memoise",
+			"Version" : "2.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"microbenchmark" : {
+			"Package" : "microbenchmark",
+			"Version" : "1.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"mime" : {
+			"Package" : "mime",
+			"Version" : "0.13",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"minqa" : {
+			"Package" : "minqa",
+			"Version" : "1.2.8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"modelr" : {
+			"Package" : "modelr",
+			"Version" : "0.1.11",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"nloptr" : {
+			"Package" : "nloptr",
+			"Version" : "2.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"prettyunits" : {
+			"Package" : "prettyunits",
+			"Version" : "1.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ps" : {
+			"Package" : "ps",
+			"Version" : "1.9.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"RcppEigen" : {
+			"Package" : "RcppEigen",
+			"Version" : "0.3.4.0.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"reformulas" : {
+			"Package" : "reformulas",
+			"Version" : "0.4.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"sass" : {
+			"Package" : "sass",
+			"Version" : "0.4.10",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"sys" : {
+			"Package" : "sys",
+			"Version" : "3.4.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"yaml" : {
+			"Package" : "yaml",
+			"Version" : "2.3.12",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"askpass" : {
+			"Package" : "askpass",
+			"Version" : "1.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"bit64" : {
+			"Package" : "bit64",
+			"Version" : "4.6.0-1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"bslib" : {
+			"Package" : "bslib",
+			"Version" : "0.10.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"shinyjs" : {
+			"Package" : "shinyjs",
+			"Version" : "2.1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"doBy" : {
+			"Package" : "doBy",
+			"Version" : "4.7.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"fontawesome" : {
+			"Package" : "fontawesome",
+			"Version" : "0.5.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"knitr" : {
+			"Package" : "knitr",
+			"Version" : "1.51",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"later" : {
+			"Package" : "later",
+			"Version" : "1.4.8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lme4" : {
+			"Package" : "lme4",
+			"Version" : "2.0-1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"MatrixModels" : {
+			"Package" : "MatrixModels",
+			"Version" : "0.5-4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"numDeriv" : {
+			"Package" : "numDeriv",
+			"Version" : "2016.8-1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"otel" : {
+			"Package" : "otel",
+			"Version" : "0.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"processx" : {
+			"Package" : "processx",
+			"Version" : "3.8.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"progress" : {
+			"Package" : "progress",
+			"Version" : "1.2.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"SparseM" : {
+			"Package" : "SparseM",
+			"Version" : "1.84-2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"survival" : {
+			"Package" : "survival",
+			"Version" : "3.8-6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tinytex" : {
+			"Package" : "tinytex",
+			"Version" : "0.58",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tzdb" : {
+			"Package" : "tzdb",
+			"Version" : "0.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"abind" : {
+			"Package" : "abind",
+			"Version" : "1.4-8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"blob" : {
+			"Package" : "blob",
+			"Version" : "1.3.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"callr" : {
+			"Package" : "callr",
+			"Version" : "3.7.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"carData" : {
+			"Package" : "carData",
+			"Version" : "3.0-6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"checkmate" : {
+			"Package" : "checkmate",
+			"Version" : "2.3.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"clipr" : {
+			"Package" : "clipr",
+			"Version" : "0.8.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"commonmark" : {
+			"Package" : "commonmark",
+			"Version" : "2.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"curl" : {
+			"Package" : "curl",
+			"Version" : "7.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"DBI" : {
+			"Package" : "DBI",
+			"Version" : "1.3.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"desc" : {
+			"Package" : "desc",
+			"Version" : "1.4.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Formula" : {
+			"Package" : "Formula",
+			"Version" : "1.2-5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"mgcv" : {
+			"Package" : "mgcv",
+			"Version" : "1.9-4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"openssl" : {
+			"Package" : "openssl",
+			"Version" : "2.3.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pbkrtest" : {
+			"Package" : "pbkrtest",
+			"Version" : "0.5.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"promises" : {
+			"Package" : "promises",
+			"Version" : "1.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"quantreg" : {
+			"Package" : "quantreg",
+			"Version" : "6.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rJava" : {
+			"Package" : "rJava",
+			"Version" : "1.0-16",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rmarkdown" : {
+			"Package" : "rmarkdown",
+			"Version" : "2.30",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"systemfonts" : {
+			"Package" : "systemfonts",
+			"Version" : "1.3.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"triebeard" : {
+			"Package" : "triebeard",
+			"Version" : "0.4.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"vroom" : {
+			"Package" : "vroom",
+			"Version" : "1.7.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"brio" : {
+			"Package" : "brio",
+			"Version" : "1.1.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"car" : {
+			"Package" : "car",
+			"Version" : "3.1-5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"corrplot" : {
+			"Package" : "corrplot",
+			"Version" : "0.95",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"credentials" : {
+			"Package" : "credentials",
+			"Version" : "2.0.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"dbplyr" : {
+			"Package" : "dbplyr",
+			"Version" : "2.5.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"diffobj" : {
+			"Package" : "diffobj",
+			"Version" : "0.3.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"duckdb" : {
+			"Package" : "duckdb",
+			"Version" : "1.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"fansi" : {
+			"Package" : "fansi",
+			"Version" : "1.0.7",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gitcreds" : {
+			"Package" : "gitcreds",
+			"Version" : "0.1.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"htmlwidgets" : {
+			"Package" : "htmlwidgets",
+			"Version" : "1.6.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"httpuv" : {
+			"Package" : "httpuv",
+			"Version" : "1.6.17",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"httr2" : {
+			"Package" : "httr2",
+			"Version" : "1.2.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ini" : {
+			"Package" : "ini",
+			"Version" : "0.3.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"litedown" : {
+			"Package" : "litedown",
+			"Version" : "0.9",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"mathjaxr" : {
+			"Package" : "mathjaxr",
+			"Version" : "2.0-0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"memuse" : {
+			"Package" : "memuse",
+			"Version" : "4.2-3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pkgbuild" : {
+			"Package" : "pkgbuild",
+			"Version" : "1.4.8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"reactR" : {
+			"Package" : "reactR",
+			"Version" : "0.6.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"readr" : {
+			"Package" : "readr",
+			"Version" : "2.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rprojroot" : {
+			"Package" : "rprojroot",
+			"Version" : "2.1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rstudioapi" : {
+			"Package" : "rstudioapi",
+			"Version" : "0.18.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"snow" : {
+			"Package" : "snow",
+			"Version" : "0.4-4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"sourcetools" : {
+			"Package" : "sourcetools",
+			"Version" : "0.1.7-1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"SqlRender" : {
+			"Package" : "SqlRender",
+			"Version" : "1.19.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"textshaping" : {
+			"Package" : "textshaping",
+			"Version" : "1.0.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"timechange" : {
+			"Package" : "timechange",
+			"Version" : "0.4.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"urltools" : {
+			"Package" : "urltools",
+			"Version" : "1.7.3.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"V8" : {
+			"Package" : "V8",
+			"Version" : "8.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"xml2" : {
+			"Package" : "xml2",
+			"Version" : "1.5.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"xtable" : {
+			"Package" : "xtable",
+			"Version" : "1.8-8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"xts" : {
+			"Package" : "xts",
+			"Version" : "0.14.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"zip" : {
+			"Package" : "zip",
+			"Version" : "2.3.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Andromeda" : {
+			"Package" : "Andromeda",
+			"Version" : "1.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"bigD" : {
+			"Package" : "bigD",
+			"Version" : "0.3.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"bitops" : {
+			"Package" : "bitops",
+			"Version" : "1.0-9",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"brew" : {
+			"Package" : "brew",
+			"Version" : "1.0-10",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"DatabaseConnector" : {
+			"Package" : "DatabaseConnector",
+			"Version" : "7.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"downlit" : {
+			"Package" : "downlit",
+			"Version" : "0.4.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gert" : {
+			"Package" : "gert",
+			"Version" : "2.3.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggrepel" : {
+			"Package" : "ggrepel",
+			"Version" : "0.9.8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggsci" : {
+			"Package" : "ggsci",
+			"Version" : "4.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggsignif" : {
+			"Package" : "ggsignif",
+			"Version" : "0.6.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gh" : {
+			"Package" : "gh",
+			"Version" : "1.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gridExtra" : {
+			"Package" : "gridExtra",
+			"Version" : "2.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"juicyjuice" : {
+			"Package" : "juicyjuice",
+			"Version" : "0.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lazyeval" : {
+			"Package" : "lazyeval",
+			"Version" : "0.2.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lubridate" : {
+			"Package" : "lubridate",
+			"Version" : "1.9.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"markdown" : {
+			"Package" : "markdown",
+			"Version" : "2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"metadat" : {
+			"Package" : "metadat",
+			"Version" : "1.4-0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ParallelLogger" : {
+			"Package" : "ParallelLogger",
+			"Version" : "3.5.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pbapply" : {
+			"Package" : "pbapply",
+			"Version" : "1.7-4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pkgload" : {
+			"Package" : "pkgload",
+			"Version" : "1.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"polynom" : {
+			"Package" : "polynom",
+			"Version" : "1.4-1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pool" : {
+			"Package" : "pool",
+			"Version" : "1.0.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"praise" : {
+			"Package" : "praise",
+			"Version" : "1.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ragg" : {
+			"Package" : "ragg",
+			"Version" : "1.5.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"reactable" : {
+			"Package" : "reactable",
+			"Version" : "0.4.5",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"RJSONIO" : {
+			"Package" : "RJSONIO",
+			"Version" : "2.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"RSQLite" : {
+			"Package" : "RSQLite",
+			"Version" : "2.4.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rstatix" : {
+			"Package" : "rstatix",
+			"Version" : "0.7.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"sessioninfo" : {
+			"Package" : "sessioninfo",
+			"Version" : "1.2.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"shiny" : {
+			"Package" : "shiny",
+			"Version" : "1.13.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"snakecase" : {
+			"Package" : "snakecase",
+			"Version" : "0.11.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"svglite" : {
+			"Package" : "svglite",
+			"Version" : "2.2.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"TTR" : {
+			"Package" : "TTR",
+			"Version" : "0.24.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"waldo" : {
+			"Package" : "waldo",
+			"Version" : "0.6.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"whisker" : {
+			"Package" : "whisker",
+			"Version" : "0.4.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"xopen" : {
+			"Package" : "xopen",
+			"Version" : "1.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"assertthat" : {
+			"Package" : "assertthat",
+			"Version" : "0.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"CirceR" : {
+			"Package" : "CirceR",
+			"Version" : "1.3.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"CompQuadForm" : {
+			"Package" : "CompQuadForm",
+			"Version" : "1.4.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"crosstalk" : {
+			"Package" : "crosstalk",
+			"Version" : "1.2.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Cyclops" : {
+			"Package" : "Cyclops",
+			"Version" : "3.7.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"data.table" : {
+			"Package" : "data.table",
+			"Version" : "1.18.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"distributional" : {
+			"Package" : "distributional",
+			"Version" : "0.7.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ellipsis" : {
+			"Package" : "ellipsis",
+			"Version" : "0.3.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"FeatureExtraction" : {
+			"Package" : "FeatureExtraction",
+			"Version" : "3.13.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"forestplot" : {
+			"Package" : "forestplot",
+			"Version" : "3.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggpubr" : {
+			"Package" : "ggpubr",
+			"Version" : "0.6.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gt" : {
+			"Package" : "gt",
+			"Version" : "1.3.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"here" : {
+			"Package" : "here",
+			"Version" : "1.0.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"httr" : {
+			"Package" : "httr",
+			"Version" : "1.4.8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"kableExtra" : {
+			"Package" : "kableExtra",
+			"Version" : "1.4.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"metafor" : {
+			"Package" : "metafor",
+			"Version" : "4.8-0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"miniUI" : {
+			"Package" : "miniUI",
+			"Version" : "0.1.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"omopgenerics" : {
+			"Package" : "omopgenerics",
+			"Version" : "1.3.7",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pak" : {
+			"Package" : "pak",
+			"Version" : "0.9.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pkgdown" : {
+			"Package" : "pkgdown",
+			"Version" : "2.2.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"png" : {
+			"Package" : "png",
+			"Version" : "0.1-9",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"pROC" : {
+			"Package" : "pROC",
+			"Version" : "1.19.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"profvis" : {
+			"Package" : "profvis",
+			"Version" : "0.4.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"PRROC" : {
+			"Package" : "PRROC",
+			"Version" : "1.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"quadprog" : {
+			"Package" : "quadprog",
+			"Version" : "1.5-8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"quantmod" : {
+			"Package" : "quantmod",
+			"Version" : "0.4.28",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"quarto" : {
+			"Package" : "quarto",
+			"Version" : "1.5.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rcmdcheck" : {
+			"Package" : "rcmdcheck",
+			"Version" : "1.4.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"RcppTOML" : {
+			"Package" : "RcppTOML",
+			"Version" : "0.2.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ResultModelManager" : {
+			"Package" : "ResultModelManager",
+			"Version" : "0.6.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"roxygen2" : {
+			"Package" : "roxygen2",
+			"Version" : "7.3.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rversions" : {
+			"Package" : "rversions",
+			"Version" : "3.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"testthat" : {
+			"Package" : "testthat",
+			"Version" : "3.3.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"urlchecker" : {
+			"Package" : "urlchecker",
+			"Version" : "1.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"usethis" : {
+			"Package" : "usethis",
+			"Version" : "3.2.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"arrow" : {
+			"Package" : "arrow",
+			"Version" : "23.0.1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"BeastJar" : {
+			"Package" : "BeastJar",
+			"Version" : "10.5.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"CDMConnector" : {
+			"Package" : "CDMConnector",
+			"Version" : "2.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"clock" : {
+			"Package" : "clock",
+			"Version" : "0.7.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"coda" : {
+			"Package" : "coda",
+			"Version" : "0.19-4.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"CohortGenerator" : {
+			"Package" : "CohortGenerator",
+			"Version" : "1.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"CommonDataModel" : {
+			"Package" : "CommonDataModel",
+			"Version" : "1.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"devtools" : {
+			"Package" : "devtools",
+			"Version" : "2.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"EmpiricalCalibration" : {
+			"Package" : "EmpiricalCalibration",
+			"Version" : "3.1.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"english" : {
+			"Package" : "english",
+			"Version" : "1.2-6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggdist" : {
+			"Package" : "ggdist",
+			"Version" : "3.3.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"HDInterval" : {
+			"Package" : "HDInterval",
+			"Version" : "0.2.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"meta" : {
+			"Package" : "meta",
+			"Version" : "8.2-1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"OhdsiReportGenerator" : {
+			"Package" : "OhdsiReportGenerator",
+			"Version" : "2.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"openxlsx" : {
+			"Package" : "openxlsx",
+			"Version" : "4.2.8.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"PatientLevelPrediction" : {
+			"Package" : "PatientLevelPrediction",
+			"Version" : "6.6.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"plotly" : {
+			"Package" : "plotly",
+			"Version" : "4.12.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"plyr" : {
+			"Package" : "plyr",
+			"Version" : "1.8.9",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"rateratio.test" : {
+			"Package" : "rateratio.test",
+			"Version" : "1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"remotes" : {
+			"Package" : "remotes",
+			"Version" : "2.5.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"reticulate" : {
+			"Package" : "reticulate",
+			"Version" : "1.45.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"shinycssloaders" : {
+			"Package" : "shinycssloaders",
+			"Version" : "1.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"shinydashboard" : {
+			"Package" : "shinydashboard",
+			"Version" : "0.7.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"shinyWidgets" : {
+			"Package" : "shinyWidgets",
+			"Version" : "0.9.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tippy" : {
+			"Package" : "tippy",
+			"Version" : "0.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"tseries" : {
+			"Package" : "tseries",
+			"Version" : "0.10-60",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Achilles" : {
+			"Package" : "Achilles",
+			"Version" : "1.7.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"BrokenAdaptiveRidge" : {
+			"Package" : "BrokenAdaptiveRidge",
+			"Version" : "1.0.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Characterization" : {
+			"Package" : "Characterization",
+			"Version" : "3.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"CohortMethod" : {
+			"Package" : "CohortMethod",
+			"Version" : "6.0.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"DataQualityDashboard" : {
+			"Package" : "DataQualityDashboard",
+			"Version" : "2.8.7",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Eunomia" : {
+			"Package" : "Eunomia",
+			"Version" : "2.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"EvidenceSynthesis" : {
+			"Package" : "EvidenceSynthesis",
+			"Version" : "1.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"IterativeHardThresholding" : {
+			"Package" : "IterativeHardThresholding",
+			"Version" : "1.0.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"OhdsiShinyAppBuilder" : {
+			"Package" : "OhdsiShinyAppBuilder",
+			"Version" : "1.0.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"SelfControlledCaseSeries" : {
+			"Package" : "SelfControlledCaseSeries",
+			"Version" : "6.1.4",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"TreatmentPatterns" : {
+			"Package" : "TreatmentPatterns",
+			"Version" : "3.1.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"lightgbm" : {
+			"Package" : "lightgbm",
+			"Version" : "4.6.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"jpeg" : {
+			"Package" : "jpeg",
+			"Version" : "0.1-11",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"exactRankTests" : {
+			"Package" : "exactRankTests",
+			"Version" : "0.8-36",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"gridtext" : {
+			"Package" : "gridtext",
+			"Version" : "0.1.6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"mvtnorm" : {
+			"Package" : "mvtnorm",
+			"Version" : "1.3-6",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ggtext" : {
+			"Package" : "ggtext",
+			"Version" : "0.1.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"maxstat" : {
+			"Package" : "maxstat",
+			"Version" : "0.7-26",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"survminer" : {
+			"Package" : "survminer",
+			"Version" : "0.5.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"xgboost" : {
+			"Package" : "xgboost",
+			"Version" : "3.2.1.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"polspline" : {
+			"Package" : "polspline",
+			"Version" : "1.1.25",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"filelock" : {
+			"Package" : "filelock",
+			"Version" : "1.0.3",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"keyring" : {
+			"Package" : "keyring",
+			"Version" : "1.4.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"aws.signature" : {
+			"Package" : "aws.signature",
+			"Version" : "0.6.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"aws.s3" : {
+			"Package" : "aws.s3",
+			"Version" : "0.3.22",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"R.methodsS3" : {
+			"Package" : "R.methodsS3",
+			"Version" : "1.8.2",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"R.oo" : {
+			"Package" : "R.oo",
+			"Version" : "1.27.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"R.utils" : {
+			"Package" : "R.utils",
+			"Version" : "2.13.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"odbc" : {
+			"Package" : "odbc",
+			"Version" : "1.6.4.1",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"coro" : {
+			"Package" : "coro",
+			"Version" : "1.1.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"ellmer" : {
+			"Package" : "ellmer",
+			"Version" : "0.4.0",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"renv" : {
+			"Package" : "renv",
+			"Version" : "1.1.8",
+			"Source" : "Repository",
+			"Repository" : "CRAN"
+		},
+		"Capr" : {
+			"Package" : "Capr",
+			"Version" : "2.1.1",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "Capr",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v2.1.1"
+		},
+		"CohortDiagnostics" : {
+			"Package" : "CohortDiagnostics",
+			"Version" : "3.4.2",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "CohortDiagnostics",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v3.4.2"
+		},
+		"CohortExplorer" : {
+			"Package" : "CohortExplorer",
+			"Version" : "0.1.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "CohortExplorer",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v0.1.0"
+		},
+		"CohortIncidence" : {
+			"Package" : "CohortIncidence",
+			"Version" : "4.1.1",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "CohortIncidence",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v4.1.1"
+		},
+		"DeepPatientLevelPrediction" : {
+			"Package" : "DeepPatientLevelPrediction",
+			"Version" : "2.3.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "DeepPatientLevelPrediction",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v2.3.0"
+		},
+		"EnsemblePatientLevelPrediction" : {
+			"Package" : "EnsemblePatientLevelPrediction",
+			"Version" : "1.0.3",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "EnsemblePatientLevelPrediction",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v1.0.3"
+		},
+		"Keeper" : {
+			"Package" : "Keeper",
+			"Version" : "v2.0.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "Keeper",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v2.0.0"
+		},
+		"MethodEvaluation" : {
+			"Package" : "MethodEvaluation",
+			"Version" : "2.4.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "MethodEvaluation",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v2.4.0"
+		},
+		"OhdsiSharing" : {
+			"Package" : "OhdsiSharing",
+			"Version" : "0.2.2",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "OhdsiSharing",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v0.2.2"
+		},
+		"OhdsiShinyModules" : {
+			"Package" : "OhdsiShinyModules",
+			"Version" : "3.5.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "OhdsiShinyModules",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v3.5.0"
+		},
+		"PhenotypeLibrary" : {
+			"Package" : "PhenotypeLibrary",
+			"Version" : "3.36.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "PhenotypeLibrary",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v3.36.0"
+		},
+		"PheValuator" : {
+			"Package" : "PheValuator",
+			"Version" : "2.2.16",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "PheValuator",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v2.2.16"
+		},
+		"ROhdsiWebApi" : {
+			"Package" : "ROhdsiWebApi",
+			"Version" : "1.3.3",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "ROhdsiWebApi",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v1.3.3"
+		},
+		"SelfControlledCohort" : {
+			"Package" : "SelfControlledCohort",
+			"Version" : "1.6.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "SelfControlledCohort",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v1.6.0"
+		},
+		"Strategus" : {
+			"Package" : "Strategus",
+			"Version" : "1.5.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "Strategus",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v1.5.0"
+		},
+		"Hades" : {
+			"Package" : "Hades",
+			"Version" : "1.20.0",
+			"Source" : "GitHub",
+			"RemoteType" : "github",
+			"RemoteHost" : "api.github.com",
+			"RemoteRepo" : "Hades",
+			"RemoteUsername" : "ohdsi",
+			"RemoteRef" : "v1.20.0"
+		}
+	}
+}

--- a/hades/validate-ohdsi.R
+++ b/hades/validate-ohdsi.R
@@ -1,0 +1,112 @@
+cat("\n")
+cat("=============================================\n")
+cat("OHDSI / HADES Databricks Image Validation\n")
+cat("=============================================\n\n")
+
+
+# ------------------------------------------------------------
+# R
+# ------------------------------------------------------------
+
+cat("R Version:\n")
+cat(R.version.string, "\n")
+cat("Library paths:\n")
+cat(paste0("  ", .libPaths(), collapse = "\n"), "\n\n")
+
+
+# ------------------------------------------------------------
+# Java / rJava
+# ------------------------------------------------------------
+
+cat("Testing Java integration...\n")
+
+if (!requireNamespace("rJava", quietly = TRUE)) {
+  stop("rJava is not installed")
+}
+
+library(rJava)
+
+.jinit()
+
+java_version <- .jcall(
+  "java/lang/System",
+  "S",
+  "getProperty",
+  "java.version"
+)
+
+cat("Java version:", java_version, "\n\n")
+
+
+# ------------------------------------------------------------
+# Core packages
+#
+# requireNamespace() loads the namespace, so this also proves each
+# package's compiled code links against the libraries present in the
+# image -- a package can install cleanly and still fail to load.
+# ------------------------------------------------------------
+
+packages <- c(
+  # foundations
+  "DatabaseConnector",
+  "SqlRender",
+  "ParallelLogger",
+  "Andromeda",
+  "Cyclops",
+  "duckdb",
+  "V8",
+  "CirceR",
+  "Eunomia",
+
+  # analytics
+  "Achilles",
+  "DataQualityDashboard",
+  "CohortGenerator",
+  "CohortDiagnostics",
+  "FeatureExtraction",
+  "PatientLevelPrediction",
+  "CohortMethod",
+  "SelfControlledCaseSeries",
+  "Characterization",
+  "ResultModelManager",
+
+  # packages installed from github.com/ohdsi
+  "Capr",
+  "Strategus",
+  "Hades"
+)
+
+
+cat("Checking OHDSI packages:\n\n")
+
+
+for (pkg in packages) {
+
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+
+    stop(
+      sprintf(
+        "Required package missing: %s",
+        pkg
+      )
+    )
+  }
+
+  version <- as.character(
+    packageVersion(pkg)
+  )
+
+  cat(
+    sprintf(
+      "%-30s %s\n",
+      pkg,
+      version
+    )
+  )
+}
+
+
+cat("\n")
+cat("=============================================\n")
+cat("OHDSI / HADES validation PASSED\n")
+cat("=============================================\n")


### PR DESCRIPTION
## Type of Change

- New Docker image

## Description

Adds a new `hades` Docker image for [HADES](https://ohdsi.github.io/Hades/) (Health Analytics Data-to-Evidence Suite), the OHDSI collection of R packages for observational health data analysis on the OMOP Common Data Model, per a collaborator request.

Two tags are published, both built from the same pinned HADES 2026Q1 lockfile (`renv.lock`, 294 packages, 278 from CRAN/PPM and 16 pulled directly from `github.com/ohdsi`), on `databricksruntime/standard:17.3-LTS`:

- **`Dockerfile_full`** → `getwilds/hades:full` — a full-parity build matching a specific production Databricks cluster environment (Databricks-hosted Posit Package Manager mirror, R compiled from source to pin the exact version, Databricks notebook integration).
- **`Dockerfile_latest`** → `getwilds/hades:latest` — currently identical to `Dockerfile_full` (see Known Limitation below).

Both restore the lockfile via the same `install-hades.R` script, using a two-pass strategy (CRAN packages first, then the full lockfile including the `ohdsi/*` GitHub remotes) to work around two `renv` failure modes on a package set this large: a single global install timeout, and GitHub remotes being scheduled before their CRAN dependencies exist. Both are validated with `validate-ohdsi.R`, which loads Java/rJava and every OHDSI package in the lockfile as a smoke test.

`hades` was added to `amd64_only_tools.txt`: CRAN/PPM binaries and several HADES dependencies (`duckdb`, `Cyclops`, compiled OHDSI packages) are amd64-only or untested on ARM64.

**Known limitation:** `Dockerfile_latest` was originally meant to be a lightweight, non-Databricks build (`rocker/r-ver` base, no from-source R compile, no notebook glue). Every leaner base attempted hit missing runtime `.so` libraries from transitive CRAN dependencies in the lockfile — packages HADES doesn't need directly, but something else in the tree pulls in (`keyring` needing `libsecret-1.so.0`, `ragg` needing `libwebpmux.so.3`, etc.), each only surfacing once the previous one was fixed. Rather than keep guessing at the dependency list build-by-build, `Dockerfile_latest` now mirrors `Dockerfile_full`'s proven dependency list so both tags publish reliably; trimming it back down is tracked as follow-up work, documented in the README's "Known Limitations" section.

## Testing

**How did you test these changes?**
`make lint IMAGE=hades` (via Docker-based hadolint after hadolint dropped out of local PATH mid-session) and the repo's `docker-update.yml` GitHub Action (manually triggered) building both `Dockerfile_full` and `Dockerfile_latest` with `--platform linux/amd64`.

**Did the tests pass?**
Yes. Both `Dockerfile_full` and `Dockerfile_latest` build successfully and pass `validate-ohdsi.R` in CI.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [x] Tested locally with `make validate IMAGE=toolname` (or manually built and verified) — see note below on `make build_amd64`
- [x] Image builds successfully for target platform(s)

## Additional Context

- Neither tag requires a `GITHUB_PAT`/GitHub token: the lockfile only resolves 16 packages from `github.com/ohdsi`, which comfortably fits under the anonymous GitHub API's 60 requests/hour limit.
- Both Dockerfiles have 3 pre-existing hadolint warnings inherited from the original collaborator-provided Dockerfile (`USER root` left set, unpinned `apt-get install` versions, `cd` instead of `WORKDIR` during the R source build). Left as-is for now since the file is intentionally kept close to the working Databricks-parity setup rather than rewritten; happy to clean these up if reviewers want, ideally as a follow-up rather than blocking this PR.
- `make build_amd64 IMAGE=hades` (and `make build`/`make validate`) do **not** work for this tool: the Makefile builds each tool using that tool's own subdirectory as build context, but these Dockerfiles' `COPY` sources are rooted at the repo root to match how `docker_update.py` builds in CI. Use `docker buildx build -f hades/Dockerfile_latest .` (from repo root) for local builds instead — documented in the README.
- Both images are large builds (294-package `renv` restore, plus a from-source R compile), so CI build times for `hades` are notably longer than most images in this repo (roughly 30+ min per tag in the runs so far).