### PR TITLE
Incorporating ref data directly into Singler WILDS Docker image

### DIFF
--- a/singler/Dockerfile_2.14.1
+++ b/singler/Dockerfile_2.14.1
@@ -18,11 +18,25 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV R_LIBS_USER=/usr/local/lib/R/site-library
 ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
 
+# Pin the ExperimentHub/AnnotationHub caches to a fixed, world-readable path
+ENV EXPERIMENT_HUB_CACHE=/opt/celldex-cache
+ENV ANNOTATION_HUB_CACHE=/opt/annotationhub-cache
+
 # Install SingleR, scran (clustering + marker gene ID), and celldex
 # (reference datasets for annotation), then smoke test
 RUN R -e "BiocManager::install(c('SingleR', 'scran', 'celldex'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
   && R -e "library(SingleR); library(scran); library(celldex); \
       packageVersion('SingleR'); packageVersion('scran'); packageVersion('celldex')"
+
+# Pre-fetch the default celldex reference (HumanPrimaryCellAtlasData, both
+# gene-symbol and Ensembl-ID variants) at build time
+RUN R -e "celldex::HumanPrimaryCellAtlasData(ensembl = FALSE); \
+      celldex::HumanPrimaryCellAtlasData(ensembl = TRUE)" \
+  && R -e "options(timeout = 5); \
+      ref <- celldex::HumanPrimaryCellAtlasData(); \
+      stopifnot(ncol(ref) > 0, length(ref\$label.main) > 0); \
+      cat('celldex cache OK:', ncol(ref), 'samples\n')" \
+  && chmod -R a+rX /opt/celldex-cache /opt/annotationhub-cache
 
 # Set working directory
 WORKDIR /data

--- a/singler/Dockerfile_latest
+++ b/singler/Dockerfile_latest
@@ -18,11 +18,25 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV R_LIBS_USER=/usr/local/lib/R/site-library
 ENV R_LIBS=/usr/local/lib/R/site-library:/usr/lib/R/site-library:/usr/lib/R/library
 
+# Pin the ExperimentHub/AnnotationHub caches to a fixed, world-readable path
+ENV EXPERIMENT_HUB_CACHE=/opt/celldex-cache
+ENV ANNOTATION_HUB_CACHE=/opt/annotationhub-cache
+
 # Install SingleR, scran (clustering + marker gene ID), and celldex
 # (reference datasets for annotation), then smoke test
 RUN R -e "BiocManager::install(c('SingleR', 'scran', 'celldex'), update=FALSE, ask=FALSE, dependencies=TRUE)" \
   && R -e "library(SingleR); library(scran); library(celldex); \
       packageVersion('SingleR'); packageVersion('scran'); packageVersion('celldex')"
+
+# Pre-fetch the default celldex reference (HumanPrimaryCellAtlasData, both
+# gene-symbol and Ensembl-ID variants) at build time
+RUN R -e "celldex::HumanPrimaryCellAtlasData(ensembl = FALSE); \
+      celldex::HumanPrimaryCellAtlasData(ensembl = TRUE)" \
+  && R -e "options(timeout = 5); \
+      ref <- celldex::HumanPrimaryCellAtlasData(); \
+      stopifnot(ncol(ref) > 0, length(ref\$label.main) > 0); \
+      cat('celldex cache OK:', ncol(ref), 'samples\n')" \
+  && chmod -R a+rX /opt/celldex-cache /opt/annotationhub-cache
 
 # Set working directory
 WORKDIR /data

--- a/singler/README.md
+++ b/singler/README.md
@@ -15,6 +15,12 @@ These Docker images are built from the Bioconductor base image (RELEASE_3_23) an
 - scran: Clustering and marker gene identification, commonly used to prepare data for SingleR annotation
 - celldex: Curated collection of reference transcriptomic datasets used as SingleR annotation references
 
+### Bundled Reference Data
+
+The `celldex` `HumanPrimaryCellAtlasData` reference (both the gene-symbol and Ensembl-ID variants) is downloaded at build time and baked into the image's ExperimentHub/AnnotationHub cache. Calling `celldex::HumanPrimaryCellAtlasData()` inside the container returns the cached data with no network access required, which makes the image usable on air-gapped HPC nodes.
+
+The cache lives at `/opt/celldex-cache` (and `/opt/annotationhub-cache`), pinned via the `EXPERIMENT_HUB_CACHE` and `ANNOTATION_HUB_CACHE` environment variables so it is found regardless of `$HOME`. This matters under Apptainer, which remaps `$HOME` to the host user's home directory. Other celldex references (for example `MonacoImmuneData` or `BlueprintEncodeData`) are not bundled and will be downloaded on first use, which requires network access.
+
 The images are designed to provide a focused environment for single-cell RNA-seq cell type annotation with SingleR and its most common companion tools.
 
 ## Platform Availability
@@ -72,7 +78,9 @@ docker run --rm -it -v /path/to/data:/data getwilds/singler:latest R
 docker run --rm -v /path/to/data:/data getwilds/singler:latest \
   Rscript /data/singler_analysis.R
 
-# Run a quick inline SingleR annotation using a celldex reference dataset
+# Run a quick inline SingleR annotation using the bundled celldex reference.
+# HumanPrimaryCellAtlasData() loads from the in-image cache, so this works
+# with no network access (for example on an air-gapped HPC node).
 docker run --rm -v /path/to/data:/data getwilds/singler:latest R -e "
   library(SingleR)
   library(celldex)
@@ -99,9 +107,11 @@ The Dockerfile follows these main steps:
 1. Uses Bioconductor RELEASE_3_23 as the base image
 2. Adds metadata labels for documentation and attribution
 3. Sets R library paths to prevent host library contamination in Apptainer
-4. Installs SingleR, scran, and celldex via BiocManager
-5. Runs a smoke test to confirm SingleR loads and reports its version
-6. Sets `/data` as the default working directory
+4. Pins the ExperimentHub/AnnotationHub cache to `/opt/celldex-cache` so bundled data is found regardless of `$HOME`
+5. Installs SingleR, scran, and celldex via BiocManager
+6. Runs a smoke test to confirm SingleR loads and reports its version
+7. Pre-fetches the `HumanPrimaryCellAtlasData` celldex reference into the image cache, verifies it loads offline, and makes the cache world-readable
+8. Sets `/data` as the default working directory
 
 ## Security Scanning and CVEs
 


### PR DESCRIPTION
## Type of Change

- Documentation update
- Other: enhancement to existing images (bundling reference data)

## Description

Bakes the default `celldex` reference dataset into both `singler` images so cell type annotation works without network access.

Changes to `singler/Dockerfile_latest` and `singler/Dockerfile_2.14.1`:

- Pre-fetch `celldex::HumanPrimaryCellAtlasData()` at build time, both the gene-symbol and Ensembl-ID variants, into the image's ExperimentHub/AnnotationHub cache.
- Pin the cache location with `EXPERIMENT_HUB_CACHE=/opt/celldex-cache` and `ANNOTATION_HUB_CACHE=/opt/annotationhub-cache`. Without a fixed path the cache is written under `/root/.cache` at build time and is not found at runtime when Apptainer remaps `$HOME` to the host user's home directory.
- Add an offline smoke test (`options(timeout = 5)`) that reloads the reference from cache and asserts it has samples and main labels, so a broken cache fails the build.
- `chmod -R a+rX` the cache directories so a non-root runtime user can read them.

`singler/README.md` gains a "Bundled Reference Data" section explaining what is cached, where, and why the env vars matter for Apptainer; an offline note on the inline annotation example; and updated Dockerfile Structure steps.

## Testing

**How did you test these changes?**

- `hadolint singler/Dockerfile_latest singler/Dockerfile_2.14.1` (passes clean)
- Build verification with `make build_amd64 IMAGE=singler` is still pending; the in-Dockerfile offline smoke test will fail the build if the cache is not populated or the `*_HUB_CACHE` env var names are not honored by the ExperimentHub/AnnotationHub versions in Bioconductor 3.23.

**Did the tests pass?**

Lint passed. Full AMD64 build not yet run.

## Checklist

- [x] Dockerfile follows naming convention (`Dockerfile_X.Y.Z` or `Dockerfile_latest`)
- [x] All required OCI metadata labels are present and accurate
- [x] `README.md` is included/updated in the tool directory
- [ ] Tested locally with `make validate IMAGE=toolname` (or manually built and verified)
- [ ] Image builds successfully for target platform(s)

## Additional Context

- Only `HumanPrimaryCellAtlasData` is bundled. Other celldex references still download on first use.